### PR TITLE
Derive catalyst `ExpressionEncoder`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,10 +11,10 @@ val inputDirectory = Def.settingKey[File]("")
 lazy val encoders = project
   .in(file("encoders"))
   .settings(
-    libraryDependencies ++= Seq(
-      sparkSql,
-      munit % Test
-    )
+    libraryDependencies ++= Seq(sparkSql, munit % Test),
+    Test / parallelExecution := false,
+    // Test / fork := true,
+    // Test / javaOptions += "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=1044"
   )
 
 lazy val examples = project

--- a/encoders/src/main/scala/sql/EncoderDerivation.scala
+++ b/encoders/src/main/scala/sql/EncoderDerivation.scala
@@ -1,52 +1,24 @@
 package sql
 
-import scala.deriving.Mirror
-import scala.reflect.ClassTag
-import scala.compiletime.{constValue, erasedValue, summonInline, error}
+import sql.derivation.{Deserializer, Serializer}
 
-import org.apache.spark.sql.{Encoder, Encoders}
-import org.apache.spark.sql.types.{DataType, StructField, StructType}
+import sql.derivation.{Deserializer, Serializer}
+
+import scala.reflect.ClassTag
+
+import org.apache.spark.sql.Encoder
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+import org.apache.spark.sql.catalyst.expressions.BoundReference
+import org.apache.spark.sql.catalyst.analysis.GetColumnByOrdinal
 
 object EncoderDerivation:
-  given Encoder[Array[Byte]] = Encoders.BINARY
-  given Encoder[String] = Encoders.STRING
-  given Encoder[Boolean] = Encoders.scalaBoolean
-  given Encoder[Byte] = Encoders.scalaByte
-  given Encoder[Short] = Encoders.scalaShort
-  given Encoder[Double] = Encoders.scalaDouble
-  given Encoder[Int] = Encoders.scalaInt
-  given Encoder[Long] = Encoders.scalaLong
-  given Encoder[Float] = Encoders.scalaFloat
-  given Encoder[java.sql.Date] = Encoders.DATE
-  given Encoder[java.sql.Timestamp] = Encoders.TIMESTAMP
-  given Encoder[java.time.Instant] = Encoders.INSTANT
-  given Encoder[java.time.LocalDate] = Encoders.LOCALDATE
-  given Encoder[java.math.BigDecimal] = Encoders.DECIMAL
-
   // TODO: Nullable field
-  inline given derived[T](using m: Mirror.Of[T], ct: ClassTag[T]): Encoder[T] = inline m match
-    case p: Mirror.ProductOf[T] => productEncoder(p, ct)
-    case s: Mirror.SumOf[T] => error("Encoders cannot be derived for Sum types. An implicit Encoder[T] is needed to store T instances in a Dataset. Primitive types (Int, String, etc) and Product types (case classes) are supported")
-
-  private inline def getNames[T <: Tuple]: List[String] = inline erasedValue[T] match
-    case _: EmptyTuple => Nil
-    case _: (t *: ts) => constValue[t].toString :: getNames[ts]
-
-  private inline def summonEncodersFromTuple[T <: Tuple]: List[Encoder[_]] = inline erasedValue[T] match
-    case _: EmptyTuple => Nil
-    case _: (t *: ts) => summonInline[Encoder[t]] :: summonEncodersFromTuple[ts]
+  given encoder[T](using serializer: Serializer[T], deserializer: Deserializer[T], classTag: ClassTag[T]): Encoder[T] =    
+    val inputObject = BoundReference(0, serializer.inputType, true)
+    val path = GetColumnByOrdinal(0, deserializer.inputType)
     
-  private inline def productEncoder[T](mirror: Mirror.ProductOf[T], ct: ClassTag[T]): Encoder[T] =
-    val encoders: List[Encoder[_]] = summonEncodersFromTuple[mirror.MirroredElemTypes]
-    val fieldNames: List[String] = getNames[mirror.MirroredElemLabels]
- 
-    new Encoder[T]:
-      override def clsTag: ClassTag[T] = ct
-      override def schema: StructType =
-        val fields = fieldNames.zip(encoders).map { (label, encoder) => 
-          val dt: DataType =
-            if encoder.schema.length > 1 then StructType(encoder.schema.fields)
-            else encoder.schema.fields.head.dataType
-          StructField(label, dt)
-        }
-        StructType(fields)
+    ExpressionEncoder(
+      serializer.serialize(inputObject),
+      deserializer.deserialize(path),
+      classTag
+    )

--- a/encoders/src/main/scala/sql/derivation/Deserializer.scala
+++ b/encoders/src/main/scala/sql/derivation/Deserializer.scala
@@ -1,0 +1,62 @@
+package sql.derivation
+
+import scala.compiletime
+import scala.deriving.Mirror
+import scala.reflect.ClassTag
+
+import org.apache.spark.sql.catalyst.expressions.{Expression, If, IsNull, Literal}
+import org.apache.spark.sql.catalyst.expressions.objects.NewInstance
+import org.apache.spark.sql.catalyst.analysis.UnresolvedExtractValue
+import org.apache.spark.sql.catalyst.DeserializerBuildHelper.*
+import org.apache.spark.sql.types.*
+
+trait Deserializer[T]:
+  def inputType: DataType
+  def deserialize(path: Expression): Expression
+
+object Deserializer:
+  given Deserializer[String] with
+    def inputType: DataType = StringType
+    def deserialize(path: Expression): Expression = 
+      createDeserializerForString(path, false)
+
+  given Deserializer[Int] with
+    def inputType: DataType = IntegerType
+    def deserialize(path: Expression): Expression =
+      createDeserializerForTypesSupportValueOf(path, classOf[java.lang.Integer])
+
+  given Deserializer[Long] with
+    def inputType: DataType = LongType
+    def deserialize(path: Expression): Expression =
+      createDeserializerForTypesSupportValueOf(path, classOf[java.lang.Long])
+
+  inline given derived[T](using m: Mirror.Of[T], ct: ClassTag[T]): Deserializer[T] = inline m match
+    case p: Mirror.ProductOf[T] => product(p, ct)
+    case s: Mirror.SumOf[T] => compiletime.error("Cannot derive Deserializer for Sum types")
+  
+  // inspired by https://github.com/apache/spark/blob/39542bb81f8570219770bb6533c077f44f6cbd2a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala#L356-L390
+  private inline def product[T](mirror: Mirror.ProductOf[T], classTag: ClassTag[T]): Deserializer[T] = 
+    val deserializers: List[Deserializer[?]] = summonTuple[mirror.MirroredElemTypes]
+    val labels: List[String] = getElemLabels[mirror.MirroredElemLabels]
+    val fields = labels.zip(deserializers)
+      .map((label, deserializer) => StructField(label, deserializer.inputType))
+    new Deserializer[T]:
+      override def inputType: StructType = StructType(fields)
+      override def deserialize(path: Expression): Expression =
+        val arguments = inputType.fields.toSeq
+          .zip(deserializers)
+          .map { (structField, deserializer) =>
+            val newPath = UnresolvedExtractValue(path, Literal(structField.name))
+            deserializer.deserialize(newPath)
+          }
+        val outputType = ObjectType(classTag.runtimeClass)
+        If(
+          IsNull(path),
+          Literal.create(null, outputType),
+          NewInstance(outputType.cls, arguments, outputType, false)
+        )
+
+  private inline def summonTuple[T <: Tuple]: List[Deserializer[?]] = inline compiletime.erasedValue[T] match
+    case _: EmptyTuple => Nil
+    case _: (t *: ts) => compiletime.summonInline[Deserializer[t]] :: summonTuple[ts]
+

--- a/encoders/src/main/scala/sql/derivation/Serializer.scala
+++ b/encoders/src/main/scala/sql/derivation/Serializer.scala
@@ -1,0 +1,49 @@
+package sql.derivation
+
+import scala.compiletime
+import scala.deriving.Mirror
+import scala.reflect.ClassTag
+
+import org.apache.spark.sql.catalyst.expressions.{Expression, KnownNotNull}
+import org.apache.spark.sql.catalyst.expressions.objects.Invoke
+import org.apache.spark.sql.catalyst.SerializerBuildHelper.*
+import org.apache.spark.sql.types.*
+
+trait Serializer[T]:
+  def inputType: DataType
+  def serialize(inputObject: Expression): Expression
+
+object Serializer:
+  given Serializer[String] with
+    def inputType: DataType = ObjectType(classOf[String])
+    def serialize(inputObject: Expression): Expression = createSerializerForString(inputObject)
+  
+  given Serializer[Int] with
+    def inputType: DataType = IntegerType
+    def serialize(inputObject: Expression): Expression = inputObject
+  given Serializer[Long] with
+    def inputType: DataType = LongType
+    def serialize(inputObject: Expression): Expression = inputObject
+
+  inline given derived[T](using m: Mirror.Of[T], ct: ClassTag[T]): Serializer[T] = inline m match
+    case p: Mirror.ProductOf[T] => product(p, ct)
+    case s: Mirror.SumOf[T] => compiletime.error("cannot derive Serializer for Sum types")
+
+  // inspired by https://github.com/apache/spark/blob/39542bb81f8570219770bb6533c077f44f6cbd2a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala#L575-L599
+  private inline def product[T](mirror: Mirror.ProductOf[T], classTag: ClassTag[T]): Serializer[T] = 
+    val serializers: List[Serializer[?]] = summonTuple[mirror.MirroredElemTypes]
+    val labels: List[String] = getElemLabels[mirror.MirroredElemLabels]
+    new Serializer[T]:
+      override def inputType: DataType = ObjectType(classTag.runtimeClass)
+      override def serialize(inputObject: Expression): Expression =
+        val fields = labels.zip(serializers)
+          .map { (label, serializer) =>
+            val fieldInputObject = Invoke(KnownNotNull(inputObject), label, serializer.inputType)
+            (label, serializer.serialize(fieldInputObject))
+          }
+        createSerializerForObject(inputObject, fields)
+    
+  private inline def summonTuple[T <: Tuple]: List[Serializer[?]] = inline compiletime.erasedValue[T] match
+    case _: EmptyTuple => Nil
+    case _: (t *: ts) => compiletime.summonInline[Serializer[t]] :: summonTuple[ts]
+

--- a/encoders/src/main/scala/sql/derivation/utils.scala
+++ b/encoders/src/main/scala/sql/derivation/utils.scala
@@ -1,0 +1,5 @@
+package sql.derivation
+
+private inline def getElemLabels[T <: Tuple]: List[String] = inline compiletime.erasedValue[T] match
+  case _: EmptyTuple => Nil
+  case _: (t *: ts) => compiletime.constValue[t].toString :: getElemLabels[ts]

--- a/encoders/src/test/scala/sql/EncoderDerivationSpec.scala
+++ b/encoders/src/test/scala/sql/EncoderDerivationSpec.scala
@@ -1,70 +1,64 @@
 package sql
 
-import org.apache.spark.sql.{Encoder, SparkSession}
+import org.apache.spark.sql.Encoder
 import org.apache.spark.sql.types._
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 
-class EncoderDerivationSpec extends munit.FunSuite:
-  import EncoderDerivation.given
+import EncoderDerivation.given
 
-  test("derive schema of case class Foo()") {
-    case class Foo()
-    assertEquals(summon[Encoder[Foo]].schema, StructType(Seq.empty))
+case class A()
+case class B(x: String)
+case class C(x: Int, y: Long)
+case class D(x: String, y: B)
+
+class EncoderDerivationSpec extends munit.FunSuite with SparkSqlTesting:
+  test("derive encoder of case class A()") {
+    val encoder = summon[Encoder[A]]
+    assertEquals(encoder.schema, StructType(Seq.empty))
+    
+    val input = Seq(A(), A())
+    assertEquals(input.toDS.collect.toSeq, input)
   }
 
-  test("derive schema of case class Foo(x: String)") {
-    case class Foo(x: String)
-    val expected = StructType(Seq(StructField("x", StringType)))
-    assertEquals(summon[Encoder[Foo]].schema, expected)
-  }
-
-  test("derive schema of case class Foo(x: String, y: Long)") {
-    case class Foo(x: String, y: Long)
-    val expected = StructType(
-      Seq(
-        StructField("x", StringType),
-        StructField("y", LongType)
-      )
+  test("derive encoder of case class B(x: String)") {
+    val encoder = summon[Encoder[B]]
+    assertEquals(
+      encoder.schema,
+      StructType(Seq(StructField("x", StringType)))
     )
-    assertEquals(summon[Encoder[Foo]].schema, expected)
+
+    val input = Seq(B("hello"), B("world"))
+    assertEquals(input.toDS.collect.toSeq, input)
   }
 
-  test("derive schema of case class Foo(x: String, y: Bar) where Bar is case class Bar(x: Int)") {
-    case class Foo(x: String, y: Bar)
-    case class Bar(x: Int)
-    val expected = StructType(
-      Seq(
-        StructField("x", StringType),
-        StructField("y", IntegerType)
-      )
-    )
-    assertEquals(summon[Encoder[Foo]].schema, expected)
-  }
-
-  test("derive schema of case class Foo(x: String, y: Bar) where Bar is case class Bar(x: Int, y: Long)") {
-    case class Foo(x: String, y: Bar)
-    case class Bar(x: Int, y: Long)
-    val expected = StructType(
-      Seq(
-        StructField("x", StringType),
-        StructField(
-          "y",
-          StructType(
-            Seq(
-              StructField("x", IntegerType),
-              StructField("y", LongType)
-            )
-          )
+  test("derive encoder of case class C(x: Int, y: Long)") {
+    val encoder = summon[Encoder[C]].asInstanceOf[ExpressionEncoder[C]]
+    assertEquals(
+      encoder.schema,
+      StructType(
+        Seq(
+          StructField("x", IntegerType),
+          StructField("y", LongType)
         )
       )
     )
-    assertEquals(summon[Encoder[Foo]].schema, expected)
+
+    val input = Seq(C(42, -9_223_372_036_854_775_808L), C(0, 9_223_372_036_854_775_807L))
+    assertEquals(input.toDS.collect.toSeq, input)
   }
 
-  test("encode dataset of case class Foo(x: String)") {
-    case class Foo(x: String)
-    val spark = SparkSession.builder().master("local").getOrCreate()
-    import spark.implicits._
-    val dataset = Seq(Foo("hello"), Foo("world")).toDS()
-    dataset.show()
-    spark.stop()
+  test("derive encoder of case class D(x: String, y: B) where B is case class B(x: String)") {
+    val encoder = summon[Encoder[D]]
+    assertEquals(
+      encoder.schema,
+      StructType(
+        Seq(
+          StructField("x", StringType),
+          StructField("y", StructType(Seq(StructField("x", StringType))))
+        )
+      )
+    )
+
+    val input = Seq(D("Hello", B("World")), D("Bye", B("Universe")))
+    assertEquals(input.toDS.collect.toSeq, input)
   }

--- a/encoders/src/test/scala/sql/SparkSqlTesting.scala
+++ b/encoders/src/test/scala/sql/SparkSqlTesting.scala
@@ -1,0 +1,10 @@
+package sql
+
+import org.apache.spark.sql.SparkSession
+
+trait SparkSqlTesting extends munit.Suite:
+  export spark.implicits._
+  val spark: SparkSession = SparkSession.builder().master("local").getOrCreate
+
+  override def afterAll(): Unit = 
+    spark.stop()


### PR DESCRIPTION
Good enough to work on simple test cases.

I was lazy and did not all the primitive types but they should be straightforward to add.

Also it is not optimized because of the unnecessary null checks.