### PR TITLE
update to spark version 3.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 ThisBuild / scalaVersion := "3.1.1"
 ThisBuild / semanticdbEnabled := true
 
-val sparkVersion = "3.2.0"
+val sparkVersion = "3.3.0"
 val sparkCore = ("org.apache.spark" %% "spark-core" % sparkVersion).cross(CrossVersion.for3Use2_13)
 val sparkSql = ("org.apache.spark" %% "spark-sql" % sparkVersion).cross(CrossVersion.for3Use2_13)
 val munit = "org.scalameta" %% "munit" % "0.7.26"


### PR DESCRIPTION
This resolves https://github.com/vincenzobaz/spark-scala3/issues/20 in the laziest way possible. It is however backwards incompatible with 3.2.0.

(side note: perhaps the spark dependency should be in `% "provided"` scope to avoid bundling it with the library itself.)