### PR TITLE
Support sequences + most types used in spark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .metals
 .vscode
 **/target
+**/metals.sbt
+project/.bloop

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,2 @@
+version = "3.7.2"
+runner.dialect = scala3

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ As of version 3.2, Spark is published for Scala 2.13, which makes it possible to
 You can add it in your `build.sbt` with:
 
 ```scala
-val sparkVersion = "3.2.0"
+val sparkVersion = "3.3.2"
 
 libraryDependencies ++= Seq(
   ("org.apache.spark" %% "spark-core" % sparkVersion).cross(CrossVersion.for3Use2_13),

--- a/README.md
+++ b/README.md
@@ -46,7 +46,3 @@ you can enable with the following import:
 ```scala
 import scala3encoders.given
 ```
-
-
-
-

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
-ThisBuild / scalaVersion := "3.1.0"
+ThisBuild / scalaVersion := "3.2.2"
 ThisBuild / semanticdbEnabled := true
 
-val sparkVersion = "3.2.0"
+val sparkVersion = "3.3.2"
 val sparkCore = ("org.apache.spark" %% "spark-core" % sparkVersion).cross(CrossVersion.for3Use2_13)
 val sparkSql = ("org.apache.spark" %% "spark-sql" % sparkVersion).cross(CrossVersion.for3Use2_13)
 val munit = "org.scalameta" %% "munit" % "0.7.26"
@@ -31,6 +31,7 @@ lazy val examples = project
     publish / skip := true,
     inputDirectory := baseDirectory.value / "input",
     buildInfoKeys := Seq[BuildInfoKey](inputDirectory),
+    libraryDependencies ++= Seq(sparkSql),
     run / fork := true
   ).settings(publishSettings)
 

--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ lazy val examples = project
     buildInfoKeys := Seq[BuildInfoKey](inputDirectory),
     libraryDependencies ++= Seq(sparkSql),
     run / fork := true,
-    javaOptions ++= unnamedJavaOptions
+    run / javaOptions ++= unnamedJavaOptions
   )
   .settings(publishSettings)
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,11 +2,34 @@ ThisBuild / scalaVersion := "3.2.2"
 ThisBuild / semanticdbEnabled := true
 
 val sparkVersion = "3.3.2"
-val sparkCore = ("org.apache.spark" %% "spark-core" % sparkVersion).cross(CrossVersion.for3Use2_13)
-val sparkSql = ("org.apache.spark" %% "spark-sql" % sparkVersion).cross(CrossVersion.for3Use2_13)
+val sparkCore = ("org.apache.spark" %% "spark-core" % sparkVersion).cross(
+  CrossVersion.for3Use2_13
+)
+val sparkSql = ("org.apache.spark" %% "spark-sql" % sparkVersion).cross(
+  CrossVersion.for3Use2_13
+)
 val munit = "org.scalameta" %% "munit" % "0.7.26"
 
 val inputDirectory = Def.settingKey[File]("")
+
+// See https://github.com/apache/spark/blob/v3.3.2/launcher/src/main/java/org/apache/spark/launcher/JavaModuleOptions.java
+val unnamedJavaOptions = List(
+  "-XX:+IgnoreUnrecognizedVMOptions",
+  "--add-opens=java.base/java.lang=ALL-UNNAMED",
+  "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED",
+  "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED",
+  "--add-opens=java.base/java.io=ALL-UNNAMED",
+  "--add-opens=java.base/java.net=ALL-UNNAMED",
+  "--add-opens=java.base/java.nio=ALL-UNNAMED",
+  "--add-opens=java.base/java.util=ALL-UNNAMED",
+  "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED",
+  "--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED",
+  "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
+  "--add-opens=java.base/sun.nio.cs=ALL-UNNAMED",
+  "--add-opens=java.base/sun.security.action=ALL-UNNAMED",
+  "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED",
+  "--add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED"
+)
 
 lazy val root = project
   .in(file("."))
@@ -19,9 +42,11 @@ lazy val encoders = project
   .settings(
     libraryDependencies ++= Seq(sparkSql, munit % Test),
     Test / parallelExecution := false,
-    // Test / fork := truek
+    Test / fork := true,
+    Test / javaOptions ++= unnamedJavaOptions
     // Test / javaOptions += "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=1044"
-  ).settings(publishSettings)
+  )
+  .settings(publishSettings)
 
 lazy val examples = project
   .in(file("examples"))
@@ -29,16 +54,21 @@ lazy val examples = project
   .dependsOn(encoders)
   .settings(
     publish / skip := true,
-    inputDirectory := baseDirectory.value / "input",
+    (inputDirectory).withRank(
+      KeyRanks.Invisible
+    ) := baseDirectory.value / "input",
     buildInfoKeys := Seq[BuildInfoKey](inputDirectory),
     libraryDependencies ++= Seq(sparkSql),
     run / fork := true
-  ).settings(publishSettings)
+  )
+  .settings(publishSettings)
 
 import xerial.sbt.Sonatype._
 lazy val publishSettings = Def.settings(
   name := "spark-scala3",
-  licenses := Seq("APL2" -> url("https://www.apache.org/licenses/LICENSE-2.0.txt")),
+  licenses := Seq(
+    "APL2" -> url("https://www.apache.org/licenses/LICENSE-2.0.txt")
+  ),
   organization := "io.github.vincenzobaz",
   homepage := Some(url("https://github.com/vincenzobaz/spark-scala3")),
   sonatypeRepository := "https://s01.oss.sonatype.org/service/local",
@@ -56,9 +86,17 @@ lazy val publishSettings = Def.settings(
       "Adrien Piquerez",
       "adrien.piquerez@gmail.com",
       url("https://github.com/adpi2")
+    ),
+    Developer(
+      "michael72",
+      "Michael Schulte",
+      "michael.schulte@gmx.org",
+      url("https://github.com/michael72")
     )
   ),
-  sonatypeProjectHosting := Some(GitHubHosting("vincenzobaz", name.value, "bazzucchi.vincenzo@gmail.com")),
+  sonatypeProjectHosting := Some(
+    GitHubHosting("vincenzobaz", name.value, "bazzucchi.vincenzo@gmail.com")
+  ),
   versionScheme := Some("early-semver"),
   versionPolicyIntention := Compatibility.None
 )

--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,8 @@ lazy val examples = project
     ) := baseDirectory.value / "input",
     buildInfoKeys := Seq[BuildInfoKey](inputDirectory),
     libraryDependencies ++= Seq(sparkSql),
-    run / fork := true
+    run / fork := true,
+    javaOptions ++= unnamedJavaOptions
   )
   .settings(publishSettings)
 

--- a/encoders/src/main/scala/scala3encoders/EncoderDerivation.scala
+++ b/encoders/src/main/scala/scala3encoders/EncoderDerivation.scala
@@ -9,10 +9,14 @@ import org.apache.spark.sql.catalyst.expressions.BoundReference
 import org.apache.spark.sql.catalyst.analysis.GetColumnByOrdinal
 
 // TODO: Nullable field
-given encoder[T](using serializer: Serializer[T], deserializer: Deserializer[T], classTag: ClassTag[T]): Encoder[T] =    
+given encoder[T](using
+    serializer: Serializer[T],
+    deserializer: Deserializer[T],
+    classTag: ClassTag[T]
+): Encoder[T] =
   val inputObject = BoundReference(0, serializer.inputType, true)
   val path = GetColumnByOrdinal(0, deserializer.inputType)
-  
+
   ExpressionEncoder(
     serializer.serialize(inputObject),
     deserializer.deserialize(path),

--- a/encoders/src/main/scala/scala3encoders/derivation/Deserializer.scala
+++ b/encoders/src/main/scala/scala3encoders/derivation/Deserializer.scala
@@ -163,7 +163,6 @@ object Deserializer:
         val arrayData = UnresolvedMapObjects(mapFunction, path)
 
         val methodName = d.inputType match
-          // TODO: replace with scala 3 reflection?
           case IntegerType => "toIntArray"
           case LongType    => "toLongArray"
           case DoubleType  => "toDoubleArray"
@@ -243,6 +242,7 @@ object Deserializer:
   private inline def summonAll[T <: Tuple, U <: Tuple]
       : List[(String, Deserializer[?])] =
     inline (erasedValue[T], erasedValue[U]) match
+      // same bulk processing as in Serializer to prevent stackoverflow on summoning decoders for large case classes
       case _: (
               t1 *: t2 *: t3 *: t4 *: t5 *: t6 *: t7 *: t8 *: t9 *: t10 *:
                 t11 *: t12 *: t13 *: t14 *: t15 *: t16 *: ts,

--- a/encoders/src/main/scala/scala3encoders/derivation/Deserializer.scala
+++ b/encoders/src/main/scala/scala3encoders/derivation/Deserializer.scala
@@ -1,10 +1,15 @@
 package scala3encoders.derivation
 
-import scala.compiletime
+import scala.compiletime.{constValue, summonInline, erasedValue}
 import scala.deriving.Mirror
 import scala.reflect.ClassTag
 
-import org.apache.spark.sql.catalyst.expressions.{Expression, If, IsNull, Literal}
+import org.apache.spark.sql.catalyst.expressions.{
+  Expression,
+  If,
+  IsNull,
+  Literal
+}
 import org.apache.spark.sql.catalyst.expressions.objects.NewInstance
 import org.apache.spark.sql.catalyst.analysis.UnresolvedExtractValue
 import org.apache.spark.sql.catalyst.DeserializerBuildHelper.*
@@ -13,12 +18,45 @@ import org.apache.spark.sql.catalyst.expressions.objects._
 import org.apache.spark.sql.types.*
 import org.apache.spark.sql.catalyst.ScalaReflection
 import org.apache.spark.sql.catalyst.WalkedTypePath
+import org.apache.spark.sql.catalyst.expressions.GetStructField
 
 trait Deserializer[T]:
   def inputType: DataType
   def deserialize(path: Expression): Expression
 
 object Deserializer:
+
+  // see ScalaReflection.deserializerFor
+  inline given deriveOpt[T](using
+      d: Deserializer[T],
+      ct: ClassTag[T]
+  ): Deserializer[Option[T]] =
+    new Deserializer[Option[T]]:
+      override def inputType: DataType =
+        ObjectType(ct.runtimeClass)
+
+      override def deserialize(path: Expression): Expression =
+        val tpe = ScalaReflection.typeBoxedJavaMapping.getOrElse(
+          d.inputType,
+          ct.runtimeClass
+        )
+        WrapOption(d.deserialize(path), ObjectType(tpe))
+
+  given Deserializer[Int] with
+    def inputType: DataType = IntegerType
+    def deserialize(path: Expression): Expression =
+      createDeserializerForTypesSupportValueOf(path, classOf[java.lang.Integer])
+
+  given Deserializer[java.lang.Integer] with
+    def inputType: DataType = IntegerType
+    def deserialize(path: Expression): Expression =
+      createDeserializerForTypesSupportValueOf(path, classOf[java.lang.Integer])
+
+  given Deserializer[Long] with
+    def inputType: DataType = LongType
+    def deserialize(path: Expression): Expression =
+      createDeserializerForTypesSupportValueOf(path, classOf[java.lang.Long])
+
   given Deserializer[Double] with
     def inputType: DataType = DoubleType
     def deserialize(path: Expression): Expression =
@@ -43,37 +81,72 @@ object Deserializer:
     def inputType: DataType = BooleanType
     def deserialize(path: Expression): Expression =
       createDeserializerForTypesSupportValueOf(path, classOf[java.lang.Boolean])
-  
-  given Deserializer[String] with
-    def inputType: DataType = StringType
-    def deserialize(path: Expression): Expression = 
-      createDeserializerForString(path, false)
 
-  given Deserializer[Int] with
-    def inputType: DataType = IntegerType
+  given Deserializer[java.time.LocalDate] with
+    def inputType: DataType = DateType
     def deserialize(path: Expression): Expression =
-      createDeserializerForTypesSupportValueOf(path, classOf[java.lang.Integer])
+      createDeserializerForLocalDate(path)
 
-  given Deserializer[Long] with
-    def inputType: DataType = LongType
+  given Deserializer[java.sql.Date] with
+    def inputType: DataType = DateType
     def deserialize(path: Expression): Expression =
-      createDeserializerForTypesSupportValueOf(path, classOf[java.lang.Long])
+      createDeserializerForSqlDate(path)
 
-  given instantDeserializer: Deserializer[java.time.Instant] with
+  given Deserializer[java.time.Instant] with
     def inputType: DataType = TimestampType
     def deserialize(path: Expression): Expression =
       createDeserializerForInstant(path)
-      
-  given deriveOpt[T](using d: Deserializer[T], ct: ClassTag[T]): Deserializer[Option[T]] =
-    new Deserializer[Option[T]]:
-      override def inputType: DataType = 
-        ObjectType(ct.runtimeClass)
-        
-      override def deserialize(path: Expression): Expression =
-        val tpe = ScalaReflection.typeBoxedJavaMapping.getOrElse(d.inputType, ct.runtimeClass)
-        WrapOption(d.deserialize(path), ObjectType(tpe))
 
-  given deriveArray[T](using d: Deserializer[T], ct: ClassTag[T]): Deserializer[Array[T]] =
+  given Deserializer[java.sql.Timestamp] with
+    def inputType: DataType = TimestampType
+    def deserialize(path: Expression): Expression =
+      createDeserializerForSqlTimestamp(path)
+
+  given Deserializer[java.time.Duration] with
+    def inputType: DataType = DayTimeIntervalType()
+    def deserialize(path: Expression): Expression =
+      createDeserializerForDuration(path)
+
+  given Deserializer[java.time.Period] with
+    def inputType: DataType = YearMonthIntervalType()
+    def deserialize(path: Expression): Expression =
+      createDeserializerForPeriod(path)
+
+  /*given deriveEnum[T](using d: Deserializer[T], ct: ClassTag[T]): Deserializer[java.lang.Enum[T]] with
+    def inputType: DataType = StringType
+    def deserialize(path: Expression): Expression =
+      createDeserializerForTypesSupportValueOf(
+          Invoke(path, "toString", ObjectType(classOf[String]), returnNullable = false),
+          // TODO !!
+          ct.getClass())*/
+
+  given Deserializer[String] with
+    def inputType: DataType = StringType
+    def deserialize(path: Expression): Expression =
+      createDeserializerForString(path, false)
+
+  given Deserializer[BigDecimal] with
+    def inputType: DataType =
+      DecimalType.SYSTEM_DEFAULT
+    def deserialize(path: Expression): Expression =
+      createDeserializerForJavaBigDecimal(path, returnNullable = false)
+
+  given Deserializer[java.math.BigInteger] with
+    def inputType: DataType =
+      DecimalType(38, 0) // .BigIntDecimal is private
+    def deserialize(path: Expression): Expression =
+      createDeserializerForJavaBigInteger(path, returnNullable = false)
+
+  given Deserializer[scala.math.BigInt] with
+    def inputType: DataType =
+      DecimalType(38, 0) // .BigIntDecimal is private
+    def deserialize(path: Expression): Expression =
+      createDeserializerForScalaBigInt(path)
+
+  inline given deriveArray[T](using
+      d: Deserializer[T],
+      ct: ClassTag[T]
+  ): Deserializer[Array[T]] =
     // TODO: nullable. walked
     new Deserializer[Array[T]]:
       override def inputType: DataType = ArrayType(d.inputType)
@@ -90,20 +163,22 @@ object Deserializer:
         val arrayData = UnresolvedMapObjects(mapFunction, path)
 
         val methodName = d.inputType match
-        // TODO: replace with scala 3 reflection?
+          // TODO: replace with scala 3 reflection?
           case IntegerType => "toIntArray"
-          case LongType => "toLongArray"
-          case DoubleType => "toDoubleArray"
-          case FloatType => "toFloatArray"
-          case ShortType => "toShortArray"
-          case ByteType => "toByteArray"
+          case LongType    => "toLongArray"
+          case DoubleType  => "toDoubleArray"
+          case FloatType   => "toFloatArray"
+          case ShortType   => "toShortArray"
+          case ByteType    => "toByteArray"
           case BooleanType => "toBooleanArray"
           // non-primitive
           case _ => "array"
 
         Invoke(arrayData, methodName, arrayClass, returnNullable = true)
 
-  inline given deriveSeq[F[_], T](using d: Deserializer[T], ct: ClassTag[T])(using F[T] <:< Seq[T]): Deserializer[F[T]] =
+  inline given deriveSeq[F[_], T](using d: Deserializer[T], ct: ClassTag[T])(
+      using F[T] <:< Seq[T]
+  ): Deserializer[F[T]] =
     // TODO: Nullable
     new Deserializer[F[T]]:
       override def inputType: DataType = ArrayType(d.inputType)
@@ -118,15 +193,19 @@ object Deserializer:
           )
         UnresolvedMapObjects(mapFunction, path, Some(classOf[Seq[T]]))
 
-  inline given derivedSet[T: Deserializer : ClassTag]: Deserializer[Set[T]] =
+  inline given derivedSet[T: Deserializer: ClassTag]: Deserializer[Set[T]] =
     val forSeq = deriveSeq[List, T]
     new Deserializer[Set[T]]:
       override def inputType: DataType = forSeq.inputType
-      override def deserialize(path: Expression): Expression = 
+      override def deserialize(path: Expression): Expression =
         val res = forSeq.deserialize(path).asInstanceOf[UnresolvedMapObjects]
-        UnresolvedMapObjects(res.function, res.child, Some(classOf[Set[T]]))        
+        UnresolvedMapObjects(res.function, res.child, Some(classOf[Set[T]]))
 
-  inline given derivedMap[K, V](using kd: Deserializer[K], vd: Deserializer[V], ct: ClassTag[Map[K, V]]): Deserializer[Map[K, V]] =
+  inline given derivedMap[K, V](using
+      kd: Deserializer[K],
+      vd: Deserializer[V],
+      ct: ClassTag[Map[K, V]]
+  ): Deserializer[Map[K, V]] =
     new Deserializer[Map[K, V]]:
       override def inputType: DataType = MapType(kd.inputType, vd.inputType)
       override def deserialize(path: Expression): Expression =
@@ -137,25 +216,61 @@ object Deserializer:
           ct.runtimeClass
         )
 
-  // inspired by https://github.com/apache/spark/blob/39542bb81f8570219770bb6533c077f44f6cbd2a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala#L356-L390
-  inline given derivedProduct[T](using mirror: Mirror.ProductOf[T], classTag: ClassTag[T]): Deserializer[T] = 
-    val deserializers: List[Deserializer[?]] = summonTuple[mirror.MirroredElemTypes]
-    val labels: List[String] = getElemLabels[mirror.MirroredElemLabels]
-    val fields = labels.zip(deserializers)
+// inspired by https://github.com/apache/spark/blob/39542bb81f8570219770bb6533c077f44f6cbd2a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala#L356-L390
+  inline given derivedProduct[T](using
+      mirror: Mirror.ProductOf[T],
+      classTag: ClassTag[T]
+  ): Deserializer[T] =
+    val elems = summonAll[mirror.MirroredElemLabels, mirror.MirroredElemTypes]
+    lazy val fields = elems
       .map((label, deserializer) => StructField(label, deserializer.inputType))
+    def cls = classTag.runtimeClass
+    def isTuple = cls.getName.startsWith("scala.Tuple")
+
     new Deserializer[T]:
-      override def inputType: StructType = StructType(fields)
+      override def inputType: DataType =
+        if (isTuple) ObjectType(cls) else StructType(fields)
       override def deserialize(path: Expression): Expression =
-        val arguments = inputType.fields.toSeq
-          .zip(deserializers)
-          .map { (structField, deserializer) =>
-            val newPath = UnresolvedExtractValue(path, Literal(structField.name))
+        val arguments = elems.zipWithIndex.map {
+          case ((label, deserializer), i) =>
+            val newPath =
+              if (isTuple) then GetStructField(path, i)
+              else UnresolvedExtractValue(path, Literal(label))
             deserializer.deserialize(newPath)
-          }
-        val outputType = ObjectType(classTag.runtimeClass)
-        NewInstance(outputType.cls, arguments, outputType, false)
+        }
+        NewInstance(cls, arguments, ObjectType(cls), false)
 
-  private inline def summonTuple[T <: Tuple]: List[Deserializer[?]] = inline compiletime.erasedValue[T] match
-    case _: EmptyTuple => Nil
-    case _: (t *: ts) => compiletime.summonInline[Deserializer[t]] :: summonTuple[ts]
-
+  private inline def summonAll[T <: Tuple, U <: Tuple]
+      : List[(String, Deserializer[?])] =
+    inline (erasedValue[T], erasedValue[U]) match
+      case _: (
+              t1 *: t2 *: t3 *: t4 *: t5 *: t6 *: t7 *: t8 *: t9 *: t10 *:
+                t11 *: t12 *: t13 *: t14 *: t15 *: t16 *: ts,
+              u1 *: u2 *: u3 *: u4 *: u5 *: u6 *: u7 *: u8 *: u9 *: u10 *:
+                u11 *: u12 *: u13 *: u14 *: u15 *: u16 *: us
+          ) =>
+        List(
+          (constValue[t1].toString, summonInline[Deserializer[u1]]),
+          (constValue[t2].toString, summonInline[Deserializer[u2]]),
+          (constValue[t3].toString, summonInline[Deserializer[u3]]),
+          (constValue[t4].toString, summonInline[Deserializer[u4]]),
+          (constValue[t5].toString, summonInline[Deserializer[u5]]),
+          (constValue[t6].toString, summonInline[Deserializer[u6]]),
+          (constValue[t7].toString, summonInline[Deserializer[u7]]),
+          (constValue[t8].toString, summonInline[Deserializer[u8]]),
+          (constValue[t9].toString, summonInline[Deserializer[u9]]),
+          (constValue[t10].toString, summonInline[Deserializer[u10]]),
+          (constValue[t11].toString, summonInline[Deserializer[u11]]),
+          (constValue[t12].toString, summonInline[Deserializer[u12]]),
+          (constValue[t13].toString, summonInline[Deserializer[u13]]),
+          (constValue[t14].toString, summonInline[Deserializer[u14]]),
+          (constValue[t15].toString, summonInline[Deserializer[u15]]),
+          (constValue[t16].toString, summonInline[Deserializer[u16]])
+        )
+          ::: summonAll[ts, us]
+      case _: ((t *: ts), (u *: us)) =>
+        (constValue[t].toString, summonInline[Deserializer[u]]) :: summonAll[
+          ts,
+          us
+        ]
+      case _ => Nil

--- a/encoders/src/main/scala/scala3encoders/derivation/Serializer.scala
+++ b/encoders/src/main/scala/scala3encoders/derivation/Serializer.scala
@@ -52,6 +52,57 @@ object Serializer:
       override def serialize(inputObject: Expression): Expression =
         s.serialize(UnwrapOption(inputType, inputObject))
 
+  inline given deriveSeq[T](using s: Serializer[T], ct: ClassTag[T]): Serializer[Seq[T]] =
+    // TODO: Nullable fields without reflection
+    new Serializer[Seq[T]]:
+      override def inputType: DataType = ArrayType(s.inputType)
+      override def serialize(inputObject: Expression): Expression =
+        s.inputType match
+          case dt: ObjectType => 
+            createSerializerForMapObjects(inputObject, dt, s.serialize(_))
+          case dt:  (BooleanType | ByteType | ShortType | IntegerType | LongType |
+                   FloatType | DoubleType) =>
+            val cls = ct.runtimeClass
+            if (cls.isArray && cls.getComponentType.isPrimitive) then
+              createSerializerForPrimitiveArray(inputObject, dt)
+            else
+              createSerializerForGenericArray(inputObject, dt, nullable = true)
+          case dt => createSerializerForGenericArray(inputObject, dt, nullable = true)
+
+  inline given deriveArray[T: Serializer: ClassTag]: Serializer[Array[T]] =
+    val forSeq = deriveSeq[T]
+    new Serializer[Array[T]]:
+      override def inputType: DataType = forSeq.inputType
+      override def serialize(inputObject: Expression) = forSeq.serialize(inputObject)
+
+  inline given deriveSet[T: Serializer : ClassTag]: Serializer[Set[T]] =
+    val forSeq = deriveSeq[T]
+    new Serializer[Set[T]]:
+      override def inputType: DataType = forSeq.inputType
+      override def serialize(inputObject: Expression) =
+        val newInput = Invoke(inputObject, "toSeq", ObjectType(classOf[Seq[_]]))
+        forSeq.serialize(newInput)
+
+  inline given deriveMap[K, V](using ks: Serializer[K], vs: Serializer[V]): Serializer[Map[K, V]] =
+    // TODO: nullables
+    new Serializer[Map[K, V]]:
+      override def inputType: DataType = MapType(ks.inputType, vs.inputType, true)
+
+      override def serialize(inputObject: Expression) =
+        createSerializerForMap(
+          inputObject,
+          MapElementInformation(
+            ks.inputType,
+            nullable = true,
+            ks.serialize(_)
+          ),
+          MapElementInformation(
+            vs.inputType,
+            nullable = true,
+            vs.serialize(_)
+          )
+        )
+
   inline given derived[T](using m: Mirror.Of[T], ct: ClassTag[T]): Serializer[T] = inline m match
     case p: Mirror.ProductOf[T] => product(p, ct)
     case s: Mirror.SumOf[T] => compiletime.error("cannot derive Serializer for Sum types")

--- a/encoders/src/main/scala/scala3encoders/derivation/Serializer.scala
+++ b/encoders/src/main/scala/scala3encoders/derivation/Serializer.scala
@@ -1,6 +1,6 @@
 package scala3encoders.derivation
 
-import scala.compiletime
+import scala.compiletime.{constValue, summonInline, erasedValue}
 import scala.deriving.Mirror
 import scala.reflect.ClassTag
 
@@ -9,12 +9,40 @@ import org.apache.spark.sql.catalyst.expressions.objects.Invoke
 import org.apache.spark.sql.catalyst.SerializerBuildHelper.*
 import org.apache.spark.sql.types.*
 import org.apache.spark.sql.catalyst.expressions.objects.UnwrapOption
+import org.apache.spark.sql.catalyst.ScalaReflection
 
 trait Serializer[T]:
   def inputType: DataType
   def serialize(inputObject: Expression): Expression
 
 object Serializer:
+  // primitive types are not nullable
+  private def isNullable(tpe: DataType): Boolean =
+    !(tpe == BooleanType || tpe == ByteType || tpe == ShortType || tpe == IntegerType || tpe == LongType ||
+      tpe == FloatType || tpe == DoubleType)
+
+  inline given deriveOpt[T](using
+      s: Serializer[T],
+      ct: ClassTag[Option[T]]
+  ): Serializer[Option[T]] =
+    new Serializer[Option[T]]:
+      override def inputType: DataType =
+        ObjectType(ct.runtimeClass)
+      override def serialize(inputObject: Expression): Expression =
+        s.serialize(UnwrapOption(s.inputType, inputObject))
+
+  given Serializer[Int] with
+    def inputType: DataType = IntegerType
+    def serialize(inputObject: Expression): Expression = inputObject
+
+  given Serializer[java.lang.Integer] with
+    def inputType: DataType = IntegerType
+    def serialize(inputObject: Expression): Expression = inputObject
+
+  given Serializer[Long] with
+    def inputType: DataType = LongType
+    def serialize(inputObject: Expression): Expression = inputObject
+
   given Serializer[Double] with
     def inputType: DataType = DoubleType
     def serialize(inputObject: Expression): Expression = inputObject
@@ -34,55 +62,96 @@ object Serializer:
   given Serializer[Boolean] with
     def inputType: DataType = BooleanType
     def serialize(inputObject: Expression): Expression = inputObject
- 
+
+  given Serializer[java.time.LocalDate] with
+    def inputType: DataType = ObjectType(classOf[java.time.LocalDate])
+    def serialize(inputObject: Expression): Expression =
+      createSerializerForJavaLocalDate(
+        inputObject
+      )
+
+  given Serializer[java.sql.Date] with
+    def inputType: DataType = ObjectType(classOf[java.sql.Date])
+    def serialize(inputObject: Expression): Expression =
+      createSerializerForSqlDate(inputObject)
+
+  given Serializer[java.time.Instant] with
+    def inputType: DataType = ObjectType(classOf[java.time.Instant])
+    def serialize(inputObject: Expression): Expression =
+      createSerializerForJavaInstant(inputObject)
+
+  given Serializer[java.sql.Timestamp] with
+    def inputType: DataType = ObjectType(classOf[java.sql.Timestamp])
+    def serialize(inputObject: Expression): Expression =
+      createSerializerForSqlTimestamp(inputObject)
+
+  given Serializer[java.time.Duration] with
+    def inputType: DataType = ObjectType(classOf[java.time.Duration])
+    def serialize(inputObject: Expression): Expression =
+      createSerializerForJavaDuration(inputObject)
+
+  given Serializer[java.time.Period] with
+    def inputType: DataType = ObjectType(classOf[java.time.Period])
+    def serialize(inputObject: Expression): Expression =
+      createSerializerForJavaPeriod(inputObject)
+
+  given Serializer[BigDecimal] with
+    def inputType: DataType = ObjectType(classOf[BigDecimal])
+    def serialize(inputObject: Expression): Expression =
+      createSerializerForScalaBigDecimal(inputObject)
+
+  given Serializer[java.math.BigInteger] with
+    def inputType: DataType = ObjectType(classOf[java.math.BigInteger])
+    def serialize(inputObject: Expression): Expression =
+      createSerializerForJavaBigInteger(inputObject)
+
+  given Serializer[scala.math.BigInt] with
+    def inputType: DataType = ObjectType(classOf[scala.math.BigInt])
+    def serialize(inputObject: Expression): Expression =
+      createSerializerForScalaBigInt(inputObject)
+
+  // TODO
+  /*given Serializer[Enum[_]] with
+    def inputType: DataType = ObjectType(classOf[Enum[_]])
+    def serialize(inputObject: Expression): Expression =
+        createSerializerForJavaEnum(inputObject)*/
+
   given Serializer[String] with
     def inputType: DataType = ObjectType(classOf[String])
-    def serialize(inputObject: Expression): Expression = createSerializerForString(inputObject)
-  
-  given Serializer[Int] with
-    def inputType: DataType = IntegerType
-    def serialize(inputObject: Expression): Expression = inputObject
+    def serialize(inputObject: Expression): Expression =
+      createSerializerForString(inputObject)
 
-  given Serializer[Long] with
-    def inputType: DataType = LongType
-    def serialize(inputObject: Expression): Expression = inputObject
-
-  given instantSerializer: Serializer[java.time.Instant] with
-    def inputType: DataType                            = ObjectType(classOf[java.time.Instant])
-    def serialize(inputObject: Expression): Expression = createSerializerForJavaInstant(inputObject)
-
-  inline given deriveOpt[T](using s: Serializer[T], ct: ClassTag[Option[T]]): Serializer[Option[T]] =
-    new Serializer[Option[T]]:
-      override def inputType: DataType = 
-        ObjectType(ct.runtimeClass)
-      override def serialize(inputObject: Expression): Expression =
-        s.serialize(UnwrapOption(s.inputType, inputObject))
-        
-
-  given deriveSeq[F[_], T](using s: Serializer[T], ct: ClassTag[F[T]])(using F[T] <:< Seq[T]): Serializer[F[T]] =
-    // TODO: Nullable fields without reflection
+  given deriveSeq[F[_], T](using s: Serializer[T])(using
+      F[T] <:< Seq[T]
+  ): Serializer[F[T]] =
     new Serializer[F[T]]:
       override def inputType: DataType = ObjectType(classOf[Seq[T]])
       override def serialize(inputObject: Expression): Expression =
         s.inputType match
-          case dt: ObjectType => 
+          case dt: ObjectType =>
             createSerializerForMapObjects(inputObject, dt, s.serialize(_))
-          case dt:  (BooleanType | ByteType | ShortType | IntegerType | LongType |
-                   FloatType | DoubleType) =>
-            val cls = ct.runtimeClass
-            if (cls.isArray && cls.getComponentType.isPrimitive) then
-              createSerializerForPrimitiveArray(inputObject, dt)
-            else
-              createSerializerForGenericArray(inputObject, dt, nullable = true)
-          case dt => createSerializerForGenericArray(inputObject, dt, nullable = true)
+          case dt =>
+            createSerializerForGenericArray(
+              inputObject,
+              dt,
+              isNullable(s.inputType)
+            )
 
-  inline given deriveArray[T: Serializer: ClassTag]: Serializer[Array[T]] =
-    val forSeq = deriveSeq[List, T]
+  inline given deriveArray[T: Serializer: ClassTag](using
+      s: Serializer[T]
+  ): Serializer[Array[T]] =
     new Serializer[Array[T]]:
       override def inputType: DataType = ObjectType(classOf[Array[T]])
-      override def serialize(inputObject: Expression) = forSeq.serialize(inputObject)
+      override def serialize(inputObject: Expression) =
+        s.inputType match
+          case dt: ObjectType =>
+            createSerializerForMapObjects(inputObject, dt, s.serialize(_))
+          case dt =>
+            if (isNullable(dt)) then
+              createSerializerForGenericArray(inputObject, dt, nullable = true)
+            else createSerializerForPrimitiveArray(inputObject, dt)
 
-  given deriveSet[T: Serializer : ClassTag]: Serializer[Set[T]] =
+  given deriveSet[T: Serializer: ClassTag]: Serializer[Set[T]] =
     val forSeq = deriveSeq[List, T]
     new Serializer[Set[T]]:
       override def inputType: DataType = ObjectType(classOf[Set[T]])
@@ -90,8 +159,10 @@ object Serializer:
         val newInput = Invoke(inputObject, "toSeq", ObjectType(classOf[Seq[_]]))
         forSeq.serialize(newInput)
 
-  inline given deriveMap[K, V](using ks: Serializer[K], vs: Serializer[V]): Serializer[Map[K, V]] =
-    // TODO: nullables
+  inline given deriveMap[K, V](using
+      ks: Serializer[K],
+      vs: Serializer[V]
+  ): Serializer[Map[K, V]] =
     new Serializer[Map[K, V]]:
       override def inputType: DataType = ObjectType(classOf[Map[K, V]])
 
@@ -100,31 +171,69 @@ object Serializer:
           inputObject,
           MapElementInformation(
             ks.inputType,
-            nullable = true,
+            nullable = isNullable(ks.inputType),
             ks.serialize(_)
           ),
           MapElementInformation(
             vs.inputType,
-            nullable = true,
+            nullable = isNullable(vs.inputType),
             vs.serialize(_)
           )
         )
 
   // inspired by https://github.com/apache/spark/blob/39542bb81f8570219770bb6533c077f44f6cbd2a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala#L575-L599
-  inline given derivedProduct[T](using mirror: Mirror.ProductOf[T], classTag: ClassTag[T]): Serializer[T] =
-    val serializers: List[Serializer[?]] = summonTuple[mirror.MirroredElemTypes]
-    val labels: List[String] = getElemLabels[mirror.MirroredElemLabels]
+  inline given derivedProduct[T](using
+      mirror: Mirror.ProductOf[T],
+      classTag: ClassTag[T]
+  ): Serializer[T] =
     new Serializer[T]:
       override def inputType: DataType = ObjectType(classTag.runtimeClass)
       override def serialize(inputObject: Expression): Expression =
-        val fields = labels.zip(serializers)
-          .map { (label, serializer) =>
-            val fieldInputObject = Invoke(KnownNotNull(inputObject), label, serializer.inputType)
-            (label, serializer.serialize(fieldInputObject))
+        val fields =
+          summonAll[mirror.MirroredElemLabels, mirror.MirroredElemTypes].map {
+            (label, serializer) =>
+              val fieldInputObject =
+                Invoke(KnownNotNull(inputObject), label, serializer.inputType)
+              (label, serializer.serialize(fieldInputObject))
           }
         createSerializerForObject(inputObject, fields)
-    
-  private inline def summonTuple[T <: Tuple]: List[Serializer[?]] = inline compiletime.erasedValue[T] match
-    case _: EmptyTuple => Nil
-    case _: (t *: ts) => compiletime.summonInline[Serializer[t]] :: summonTuple[ts]
 
+  private inline def summonAll[T <: Tuple, U <: Tuple]
+      : List[(String, Serializer[?])] =
+    inline (erasedValue[T], erasedValue[U]) match
+      // to support case classes with larger number of parameters we have to
+      // unpack the members in bigger chunks to not evoke a compiler stackoverflow here
+      // also Xmax-inlines may not need to be adapted
+      case _: (
+              t1 *: t2 *: t3 *: t4 *: t5 *: t6 *: t7 *: t8 *: t9 *: t10 *:
+                t11 *: t12 *: t13 *: t14 *: t15 *: t16 *: ts,
+              u1 *: u2 *: u3 *: u4 *: u5 *: u6 *: u7 *: u8 *: u9 *: u10 *:
+                u11 *: u12 *: u13 *: u14 *: u15 *: u16 *: us
+          ) =>
+        List(
+          (constValue[t1].toString, summonInline[Serializer[u1]]),
+          (constValue[t2].toString, summonInline[Serializer[u2]]),
+          (constValue[t3].toString, summonInline[Serializer[u3]]),
+          (constValue[t4].toString, summonInline[Serializer[u4]]),
+          (constValue[t5].toString, summonInline[Serializer[u5]]),
+          (constValue[t6].toString, summonInline[Serializer[u6]]),
+          (constValue[t7].toString, summonInline[Serializer[u7]]),
+          (constValue[t8].toString, summonInline[Serializer[u8]]),
+          (constValue[t9].toString, summonInline[Serializer[u9]]),
+          (constValue[t10].toString, summonInline[Serializer[u10]]),
+          (constValue[t11].toString, summonInline[Serializer[u11]]),
+          (constValue[t12].toString, summonInline[Serializer[u12]]),
+          (constValue[t13].toString, summonInline[Serializer[u13]]),
+          (constValue[t14].toString, summonInline[Serializer[u14]]),
+          (constValue[t15].toString, summonInline[Serializer[u15]]),
+          (constValue[t16].toString, summonInline[Serializer[u16]])
+        )
+          ::: summonAll[ts, us]
+
+      case _: ((t *: ts), (u *: us)) =>
+        (constValue[t].toString, summonInline[Serializer[u]]) :: summonAll[
+          ts,
+          us
+        ]
+
+      case _ => Nil

--- a/encoders/src/main/scala/scala3encoders/derivation/Serializer.scala
+++ b/encoders/src/main/scala/scala3encoders/derivation/Serializer.scala
@@ -51,13 +51,12 @@ object Serializer:
     def inputType: DataType                            = ObjectType(classOf[java.time.Instant])
     def serialize(inputObject: Expression): Expression = createSerializerForJavaInstant(inputObject)
 
-  inline given deriveOpt[T](using s: Serializer[T], ct: ClassTag[T]): Serializer[Option[T]] =
+  inline given deriveOpt[T](using s: Serializer[T], ct: ClassTag[Option[T]]): Serializer[Option[T]] =
     new Serializer[Option[T]]:
       override def inputType: DataType = 
-        ObjectType(classOf[Option[T]])
+        ObjectType(ct.runtimeClass)
       override def serialize(inputObject: Expression): Expression =
-        // TOOD serialize basic types
-        s.serialize(UnwrapOption(ObjectType(ct.runtimeClass), inputObject))
+        s.serialize(UnwrapOption(s.inputType, inputObject))
         
 
   given deriveSeq[F[_], T](using s: Serializer[T], ct: ClassTag[F[T]])(using F[T] <:< Seq[T]): Serializer[F[T]] =

--- a/encoders/src/main/scala/scala3encoders/derivation/utils.scala
+++ b/encoders/src/main/scala/scala3encoders/derivation/utils.scala
@@ -1,5 +1,0 @@
-package scala3encoders.derivation
-
-private inline def getElemLabels[T <: Tuple]: List[String] = inline compiletime.erasedValue[T] match
-  case _: EmptyTuple => Nil
-  case _: (t *: ts) => compiletime.constValue[t].toString :: getElemLabels[ts]

--- a/encoders/src/test/scala/sql/DerivationTests.scala
+++ b/encoders/src/test/scala/sql/DerivationTests.scala
@@ -24,7 +24,7 @@ class DerivationTests extends munit.FunSuite:
       encoderBase.schema,
       StructType(
         Seq(
-          StructField("value", ArrayType(IntegerType, true), true)
+          StructField("value", ArrayType(IntegerType, false), true)
         )
       )
     )
@@ -46,7 +46,7 @@ class DerivationTests extends munit.FunSuite:
       encoderBase.schema,
       StructType(
         Seq(
-          StructField("value", ArrayType(IntegerType, true), true)
+          StructField("value", ArrayType(IntegerType, false), true)
         )
       )
     )
@@ -68,7 +68,7 @@ class DerivationTests extends munit.FunSuite:
       encoderBase.schema,
       StructType(
         Seq(
-          StructField("value", ArrayType(IntegerType, true), true)
+          StructField("value", ArrayType(IntegerType, false), true)
         )
       )
     )

--- a/encoders/src/test/scala/sql/DerivationTests.scala
+++ b/encoders/src/test/scala/sql/DerivationTests.scala
@@ -1,0 +1,121 @@
+package scala3encoders
+
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+import org.apache.spark.sql.Encoder
+import org.apache.spark.sql.types._
+
+class DerivationTests extends munit.FunSuite:
+  test("derive encoder of case class C(x: Int, y: Long)") {
+    val encoder = summon[Encoder[C]].asInstanceOf[ExpressionEncoder[C]]
+    assertEquals(
+      encoder.schema,
+      StructType(
+        Seq(
+          StructField("x", IntegerType),
+          StructField("y", LongType)
+        )
+      )
+    )
+  }
+
+  test("derive encoder of Seq") {
+    val encoderBase = summon[Encoder[Seq[Int]]]
+    assertEquals(
+      encoderBase.schema,
+      StructType(
+        Seq(
+          StructField("value", ArrayType(IntegerType, true), true)
+        )
+      )
+    )
+
+    val encoderAdv = summon[Encoder[Seq[D]]]
+    assertEquals(
+      encoderAdv.schema,
+      StructType(
+        Seq(
+          StructField("value", ArrayType(dSchema, true), true)
+        )
+      )
+    )
+  }
+
+  test("derive encoder of Set") {
+    val encoderBase = summon[Encoder[Set[Int]]]
+    assertEquals(
+      encoderBase.schema,
+      StructType(
+        Seq(
+          StructField("value", ArrayType(IntegerType, true), true)
+        )
+      )
+    )
+
+    val encoderAdv = summon[Encoder[Set[D]]]
+    assertEquals(
+      encoderAdv.schema,
+      StructType(
+        Seq(
+          StructField("value", ArrayType(dSchema, true), true)
+        )
+      )
+    )
+  }
+
+  test("derive encoder of Array") {
+    val encoderBase = summon[Encoder[Array[Int]]]
+    assertEquals(
+      encoderBase.schema,
+      StructType(
+        Seq(
+          StructField("value", ArrayType(IntegerType, true), true)
+        )
+      )
+    )
+
+    val encoderAdv = summon[Encoder[Array[D]]]
+    assertEquals(
+      encoderAdv.schema,
+      StructType(
+        Seq(
+          StructField("value", ArrayType(dSchema, true), true)
+        )
+      )
+    )
+  }
+
+  test("derive encoder of Map") {
+    val encoderBase = summon[Encoder[Map[Int, String]]]
+    assertEquals(
+      encoderBase.schema,
+      StructType(
+        Seq(
+          StructField(
+            "value",
+            MapType(
+              IntegerType,
+              StringType,
+              true
+            )
+          )
+        )
+      )
+    )
+
+    val encoderAdv = summon[Encoder[Map[D, D]]]
+    assertEquals(
+      encoderAdv.schema,
+      StructType(
+        Seq(
+          StructField(
+            "value",
+            MapType(
+              dSchema,
+              dSchema,
+              true
+            )
+          )
+        )
+      )
+    )
+  }

--- a/encoders/src/test/scala/sql/EncoderDerivationSpec.scala
+++ b/encoders/src/test/scala/sql/EncoderDerivationSpec.scala
@@ -84,8 +84,7 @@ class EncoderDerivationSpec extends munit.FunSuite with SparkSqlTesting:
     val encoder = summon[Encoder[E]]
     val input = Seq(E(Map("a" -> Seq("foo", "bar")), Array(1,2,3,4,5), Set(1.0, 2.0), java.time.Instant.now(), Some("whoo"), None),
       E(null, Array(1,2), Set(1.0, 2.0), java.time.Instant.now(), None, Some(1L)))
-    val ds = input.toDS
-    val res = ds.collect.toSeq
+    val res = input.toDS.collect.toSeq
     assertEquals(res.map(_.x), input.map(_.x))
     assert(res.map(_.y).zip(input.map(_.y)).forall(y => y._1.sameElements(y._2)))
     assertEquals(res.map(_.z), input.map(_.z))

--- a/encoders/src/test/scala/sql/EncoderDerivationSpec.scala
+++ b/encoders/src/test/scala/sql/EncoderDerivationSpec.scala
@@ -80,6 +80,26 @@ class EncoderDerivationSpec extends munit.FunSuite with SparkSqlTesting:
     assertEquals(input.toDS.collect.toSeq, input)
   }
 
+  test("List[Int]") {
+    val ls = List(List(1,2,3), List(4,5,6))
+    assertEquals(ls.toDS.collect().toList, ls)
+  }
+
+  test("List[case class]") {
+    case class Sequence(id: Int, nums: List[Int])
+
+    val seq1 = Sequence(0, 2 :: 3 :: Nil)
+    val seq2 = Sequence(1, 4 :: 5 :: Nil)
+    val seq3 = Sequence(2, 7 :: 8 :: 9 :: Nil)
+
+    val seqs = seq1 :: seq2 :: seq3 :: Nil
+
+    assertEquals(
+      seqs.toDS.collect().toList,
+      seqs
+    )
+  }
+
   test("Issue 14") {
     case class City(name: String, lat: Double, lon: Double)
     case class Journey(id: Int, cities: List[City])
@@ -91,8 +111,9 @@ class EncoderDerivationSpec extends munit.FunSuite with SparkSqlTesting:
 
     val trip1 = Journey(0, rome :: paris :: Nil)
     val trip2 = Journey(1, berlin :: madrid :: Nil)
+    val trip3 = Journey(2, berlin :: madrid :: paris :: Nil)
 
-    val trips = trip1 :: trip2 :: Nil
+    val trips = trip1 :: trip2 :: trip3 :: Nil
 
     val idsIncrement = trips.toDS.map(tr => tr.copy(id = tr.id + 1))
 

--- a/encoders/src/test/scala/sql/EncoderDerivationSpec.scala
+++ b/encoders/src/test/scala/sql/EncoderDerivationSpec.scala
@@ -2,13 +2,130 @@ package scala3encoders
 
 import org.apache.spark.sql.Encoder
 import org.apache.spark.sql.types._
+import org.apache.spark.sql.functions._
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 
 case class A()
 case class B(x: String)
 case class C(x: Int, y: Long)
 case class D(x: String, y: B)
-case class E(x: Map[String, Seq[String]], y: Array[Int], z: Set[Double], u: java.time.Instant, v: Option[String], w: Option[Long])
+case class E(x: Map[String, Seq[String]], y: Array[Int], z: Set[Double])
+case class F(v: Option[String], w: Option[Long])
+case class Dates(u: java.time.Instant)
+case class ChkTuple(
+    tup: (String, Option[Int]),
+    content: Map[(String, java.time.LocalDate), Long],
+    i: Int
+)
+case class Pos(x: Int, y: Int, z: Long)
+case class Big(
+    i00: Int,
+    i01: Int,
+    i02: Int,
+    i03: Int,
+    i04: Int,
+    i05: Int,
+    i06: Int,
+    i07: Int,
+    i08: Int,
+    i09: Int,
+    i10: Int,
+    i11: Int,
+    i12: Int,
+    i13: Int,
+    i14: Int,
+    i15: Int,
+    i16: Int,
+    i17: Int,
+    i18: Int,
+    i19: Int,
+    i20: Int,
+    i21: Int,
+    i22: Int,
+    i23: Int,
+    i24: Int,
+    i25: Int,
+    i26: Int,
+    i27: Int,
+    i28: Int,
+    i29: Int,
+    i30: Int,
+    i31: Int,
+    i32: Int,
+    i33: Int,
+    i34: Int,
+    i35: Int,
+    i36: Int,
+    i37: Int,
+    i38: Int,
+    i39: Int,
+    i40: Int,
+    i41: Int,
+    i42: Int,
+    i43: Int,
+    i44: Int,
+    i45: Int,
+    i46: Int,
+    i47: Int,
+    i48: Int,
+    i49: Int,
+    i50: Int,
+    i51: Int,
+    i52: Int,
+    i53: Int,
+    i54: Int,
+    i55: Int,
+    i56: Int,
+    i57: Int,
+    i58: Int,
+    i59: Int,
+    i60: Int,
+    i61: Int,
+    i62: Int,
+    i63: Int,
+    i64: Int,
+    i65: Int,
+    i66: Int,
+    i67: Int,
+    i68: Int,
+    i69: Int,
+    i70: Int,
+    i71: Int,
+    i72: Int,
+    i73: Int,
+    i74: Int,
+    i75: Int,
+    i76: Int,
+    i77: Int,
+    i78: Int,
+    i79: Int,
+    i80: Int,
+    i81: Int,
+    i82: Int,
+    i83: Int,
+    i84: Int,
+    i85: Int,
+    i86: Int,
+    i87: Int,
+    i88: Int,
+    i89: Int,
+    i90: Int,
+    i91: Int,
+    i92: Int,
+    i93: Int,
+    i94: Int,
+    i95: Int,
+    i96: Int,
+    i97: Int,
+    i98: Int,
+    i99: Int
+)
+
+final case class Key(id: String, date: java.time.LocalDate)
+final case class ChkMap(
+    id: Int,
+    m: Map[Key, Long]
+)
 
 case class Sequence(id: Int, nums: Seq[Int])
 
@@ -60,6 +177,22 @@ class EncoderDerivationSpec extends munit.FunSuite with SparkSqlTesting:
     assertEquals(input.toDS.collect.toSeq, input)
   }
 
+  test("derive encoder of case class Pos and collect as tuple") {
+    val encoder = summon[Encoder[Pos]].asInstanceOf[ExpressionEncoder[Pos]]
+    val input = Seq(Pos(1, 2, 3L), Pos(4, 5, 6))
+
+    val res = input
+      .toDF()
+      .select(col("x"), col("z"))
+      .distinct
+      .as[(Int, Long)]
+      .collect()
+      .toSet
+    println(res)
+    val cmp = Set[(Int, Long)]((1, 3L), (4, 6L))
+    assertEquals(res, cmp)
+  }
+
   test(
     "derive encoder of case class D(x: String, y: B) where B is case class B(x: String)"
   ) {
@@ -79,15 +212,54 @@ class EncoderDerivationSpec extends munit.FunSuite with SparkSqlTesting:
   }
 
   test(
-    "derive encoder of case class E"
+    "derive encoder of case class E(x: Map[String, Seq[String]], y: Array[Int], z: Set[Double], u: java.time.Instant)"
   ) {
     val encoder = summon[Encoder[E]]
-    val input = Seq(E(Map("a" -> Seq("foo", "bar")), Array(1,2,3,4,5), Set(1.0, 2.0), java.time.Instant.now(), Some("whoo"), None),
-      E(null, Array(1,2), Set(1.0, 2.0), java.time.Instant.now(), None, Some(1L)))
+    val input = Seq(
+      E(Map("a" -> Seq("foo", "bar")), Array(1, 2, 3, 4, 5), Set(1.0, 2.0)),
+      E(null, Array(1, 2), Set(1.0, 2.0)),
+      E(Map(), null, null)
+    )
     val res = input.toDS.collect.toSeq
     assertEquals(res.map(_.x), input.map(_.x))
-    assert(res.map(_.y).zip(input.map(_.y)).forall(y => y._1.sameElements(y._2)))
+    assert(
+      res
+        .map(_.y)
+        .zip(input.map(_.y))
+        .forall(y => (y._1 == null && y._2 == null) || y._1.sameElements(y._2))
+    )
     assertEquals(res.map(_.z), input.map(_.z))
+  }
+
+  test(
+    "derive encoder of case class F"
+  ) {
+    val encoder = summon[Encoder[F]]
+    val input = Seq(F(Some("whoo"), None), F(None, Some(1L)), F(null, null))
+    val res = input.toDS.collect.toSeq
+    assertEquals(res(0), input(0))
+    assertEquals(res(1), input(1))
+    // null will be mapped to None
+    assertEquals(res(2)._1, None)
+    assertEquals(res(2)._2, None)
+  }
+
+  test(
+    "derive encoder of case class ChkTuple"
+  ) {
+    val encoder = summon[Encoder[ChkTuple]]
+    val input = Seq(
+      ChkTuple(("Foo", Some(1)), Map(), 1),
+      ChkTuple(
+        ("Bar", None),
+        Map(
+          ("foo", java.time.LocalDate.now().minusDays(10)) -> 1L,
+          ("bar", java.time.LocalDate.now().minusDays(1)) -> 2L
+        ),
+        2
+      )
+    )
+    assertEquals(input.toDS.collect.toSeq, input)
   }
 
   test("derive encoder of case class A()") {
@@ -99,7 +271,7 @@ class EncoderDerivationSpec extends munit.FunSuite with SparkSqlTesting:
   }
 
   test("List[Int]") {
-    val ls = List(List(1,2,3), List(4,5,6))
+    val ls = List(List(1, 2, 3), List(4, 5, 6))
     assertEquals(ls.toDS.collect().toList, ls)
   }
 
@@ -134,4 +306,51 @@ class EncoderDerivationSpec extends munit.FunSuite with SparkSqlTesting:
       idsIncrement.collect().toList,
       trips.map(tr => tr.copy(id = tr.id + 1))
     )
+  }
+
+  test("ChkMap") {
+    val encoder = summon[Encoder[ChkMap]]
+    assertEquals(
+      encoder.schema,
+      StructType(
+        Seq(
+          StructField("id", IntegerType, true),
+          StructField(
+            "m",
+            MapType(
+              StructType(
+                Seq(
+                  StructField("id", StringType, true),
+                  StructField("date", DateType, true)
+                )
+              ),
+              LongType,
+              false
+            ),
+            true
+          )
+        )
+      )
+    )
+
+    val input = Seq(
+      ChkMap(
+        0,
+        Map(Key("foo", java.time.LocalDate.now().minusDays(10)) -> 123L)
+      )
+    )
+    assertEquals(input.toDS.collect.toSeq, input)
+  }
+
+  test("check Big class") {
+    val encoder = summon[Encoder[Big]]
+    val input = Seq(
+      Big(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+        20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37,
+        38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55,
+        56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73,
+        74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91,
+        92, 93, 94, 95, 96, 97, 98, 99)
+    )
+    assertEquals(input.toDS.collect.toSeq, input)
   }

--- a/encoders/src/test/scala/sql/EncoderDerivationSpec.scala
+++ b/encoders/src/test/scala/sql/EncoderDerivationSpec.scala
@@ -10,6 +10,14 @@ case class C(x: Int, y: Long)
 case class D(x: String, y: B)
 
 class EncoderDerivationSpec extends munit.FunSuite with SparkSqlTesting:
+  private val dSchema = 
+    StructType(
+      Seq(
+        StructField("x", StringType),
+        StructField("y", StructType(Seq(StructField("x", StringType))))
+      )
+    )
+
   test("derive encoder of case class A()") {
     val encoder = summon[Encoder[A]]
     assertEquals(encoder.schema, StructType(Seq.empty))
@@ -59,4 +67,107 @@ class EncoderDerivationSpec extends munit.FunSuite with SparkSqlTesting:
 
     val input = Seq(D("Hello", B("World")), D("Bye", B("Universe")))
     assertEquals(input.toDS.collect.toSeq, input)
+  }
+
+  test("derive encoder of Seq") {
+    val encoderBase = summon[Encoder[Seq[Int]]]
+    assertEquals(
+      encoderBase.schema,
+      StructType(
+        Seq(
+          StructField("value", ArrayType(IntegerType, true), true)
+        )
+      )
+    )
+
+    val encoderAdv = summon[Encoder[Seq[D]]]
+    assertEquals(
+      encoderAdv.schema,
+      StructType(
+        Seq(
+          StructField("value", ArrayType(dSchema, true), true)
+        )
+      )
+    )
+
+  }
+
+  test("derive encoder of Set") {
+    val encoderBase = summon[Encoder[Set[Int]]]
+    assertEquals(
+      encoderBase.schema,
+      StructType(
+        Seq(
+          StructField("value", ArrayType(IntegerType, true), true)
+        )
+      )
+    )
+
+    val encoderAdv = summon[Encoder[Set[D]]]
+    assertEquals(
+      encoderAdv.schema,
+      StructType(
+        Seq(
+          StructField("value", ArrayType(dSchema, true), true)
+        )
+      )
+    )
+  }
+
+  test("derive encoder of Array") {
+    val encoderBase = summon[Encoder[Array[Int]]]
+    assertEquals(
+      encoderBase.schema,
+      StructType(
+        Seq(
+          StructField("value", ArrayType(IntegerType, false), true)
+        )
+      )
+    )
+
+    val encoderAdv = summon[Encoder[Array[D]]]
+    assertEquals(
+      encoderAdv.schema,
+      StructType(
+        Seq(
+          StructField("value", ArrayType(dSchema, true), true)
+        )
+      )
+    )
+  }
+
+  test("derive encoder of Map") {
+    val encoderBase = summon[Encoder[Map[Int, String]]]
+    assertEquals(
+      encoderBase.schema,
+      StructType(
+        Seq(
+          StructField(
+            "value",
+            MapType(
+              IntegerType,
+              StringType,
+              true
+            )
+          )
+        )
+      )
+    )
+
+    val encoderAdv = summon[Encoder[Map[D, D]]]
+    assertEquals(
+      encoderAdv.schema,
+      StructType(
+        Seq(
+          StructField(
+            "value",
+            MapType(
+              dSchema,
+              dSchema,
+              true
+            )
+          )
+        )
+      )
+    )
   }

--- a/encoders/src/test/scala/sql/SparkSqlTesting.scala
+++ b/encoders/src/test/scala/sql/SparkSqlTesting.scala
@@ -6,5 +6,5 @@ trait SparkSqlTesting extends munit.Suite:
   export spark.implicits._
   val spark: SparkSession = SparkSession.builder().master("local").getOrCreate
 
-  override def afterAll(): Unit = 
+  override def afterAll(): Unit =
     spark.stop()

--- a/examples/src/main/scala/rdd/WordCount.scala
+++ b/examples/src/main/scala/rdd/WordCount.scala
@@ -9,10 +9,9 @@ import buildinfo.BuildInfo.inputDirectory
     val sc = spark.sparkContext
 
     val textFile = sc.textFile(inputDirectory.getPath + "/lorem-ipsum.txt")
-    val counts = textFile.flatMap(line => line.split(" "))
-                   .map(word => (word, 1))
-                   .reduceByKey(_ + _)
+    val counts = textFile
+      .flatMap(line => line.split(" "))
+      .map(word => (word, 1))
+      .reduceByKey(_ + _)
     counts.collect.foreach(println)
-  finally
-    spark.close()
-
+  finally spark.close()

--- a/examples/src/main/scala/rdd/WordCountSql.scala
+++ b/examples/src/main/scala/rdd/WordCountSql.scala
@@ -17,14 +17,12 @@ import scala3encoders.given
     val textFile = sc.textFile(inputDirectory.getPath + "/lorem-ipsum.txt")
     val words: Dataset[String] = textFile.flatMap(line => line.split(" ")).toDS
 
-    val counts: Dataset[(String, Double)] = 
+    val counts: Dataset[(String, Double)] =
       words
         .map(word => (word, 1d))
         .groupByKey((word, _) => word)
         .reduceGroups((a, b) => (a._1, a._2 + b._2))
         .map(_._2)
 
-    counts.show 
-  finally
-    spark.close()
-
+    counts.show
+  finally spark.close()

--- a/examples/src/main/scala/sql/StarWars.scala
+++ b/examples/src/main/scala/sql/StarWars.scala
@@ -5,78 +5,80 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.{Dataset, DataFrame, SparkSession}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql._
+import buildinfo.BuildInfo.inputDirectory
 
 object StarWars extends App:
   val spark = SparkSession.builder().master("local").getOrCreate
   import spark.implicits.localSeqToDatasetHolder
   import scala3encoders.given
 
-  extension [T: Encoder](seq: Seq[T])
-    def toDS: Dataset[T] =
-      localSeqToDatasetHolder(seq).toDS
+  try
+    extension [T: Encoder](seq: Seq[T])
+      def toDS: Dataset[T] =
+        localSeqToDatasetHolder(seq).toDS
 
-  case class Friends(name: String, friends: String)
-  val df: Dataset[Friends] = Seq(
-    ("Yoda", "Obi-Wan Kenobi"),
-    ("Anakin Skywalker", "Sheev Palpatine"),
-    ("Luke Skywalker", "Han Solo, Leia Skywalker"),
-    ("Leia Skywalker", "Obi-Wan Kenobi"),
-    ("Sheev Palpatine", "Anakin Skywalker"),
-    ("Han Solo", "Leia Skywalker, Luke Skywalker, Obi-Wan Kenobi, Chewbacca"),
-    ("Obi-Wan Kenobi", "Yoda, Qui-Gon Jinn"),
-    ("R2-D2", "C-3PO"),
-    ("C-3PO", "R2-D2"),
-    ("Darth Maul", "Sheev Palpatine"),
-    ("Chewbacca", "Han Solo"),
-    ("Lando Calrissian", "Han Solo"),
-    ("Jabba", "Boba Fett")
-  ).toDS.map((n, f) => Friends(n, f))
+    case class Friends(name: String, friends: String)
+    val friends: Dataset[Friends] = Seq(
+      ("Yoda", "Obi-Wan Kenobi"),
+      ("Anakin Skywalker", "Sheev Palpatine"),
+      ("Luke Skywalker", "Han Solo, Leia Skywalker"),
+      ("Leia Skywalker", "Obi-Wan Kenobi"),
+      ("Sheev Palpatine", "Anakin Skywalker"),
+      ("Han Solo", "Leia Skywalker, Luke Skywalker, Obi-Wan Kenobi, Chewbacca"),
+      ("Obi-Wan Kenobi", "Yoda, Qui-Gon Jinn"),
+      ("R2-D2", "C-3PO"),
+      ("C-3PO", "R2-D2"),
+      ("Darth Maul", "Sheev Palpatine"),
+      ("Chewbacca", "Han Solo"),
+      ("Lando Calrissian", "Han Solo"),
+      ("Jabba", "Boba Fett")
+    ).map(Friends.apply).toDS
 
-  val friends = df.as[Friends]
-  friends.show()
-  case class FriendsMissing(who: String, friends: Option[String])
-  val dsMissing: Dataset[FriendsMissing] = Seq(
-    ("Yoda", Some("Obi-Wan Kenobi")),
-    ("Anakin Skywalker", Some("Sheev Palpatine")),
-    ("Luke Skywalker", Option.empty[String]),
-    ("Leia Skywalker", Some("Obi-Wan Kenobi")),
-    ("Sheev Palpatine", Some("Anakin Skywalker")),
-    ("Han Solo", Some("Leia Skywalker, Luke Skywalker, Obi-Wan Kenobi"))
-  ).toDS
-    .map((a, b) => FriendsMissing(a, b))
+    friends.show()
+    case class FriendsMissing(who: String, friends: Option[String])
+    val dsMissing: Dataset[FriendsMissing] = Seq(
+      ("Yoda", Some("Obi-Wan Kenobi")),
+      ("Anakin Skywalker", Some("Sheev Palpatine")),
+      ("Luke Skywalker", Option.empty[String]),
+      ("Leia Skywalker", Some("Obi-Wan Kenobi")),
+      ("Sheev Palpatine", Some("Anakin Skywalker")),
+      ("Han Solo", Some("Leia Skywalker, Luke Skywalker, Obi-Wan Kenobi"))
+    ).map(FriendsMissing.apply).toDS
 
-  dsMissing.show()
+    dsMissing.show()
 
-  case class Character(
-      name: String,
-      height: Int,
-      weight: Option[Int],
-      eyecolor: Option[String],
-      haircolor: Option[String],
-      jedi: String,
-      species: String
-  )
+    case class Character(
+        name: String,
+        height: Int,
+        weight: Option[Int],
+        eyecolor: Option[String],
+        haircolor: Option[String],
+        jedi: String,
+        species: String
+    )
 
-  val characters: Dataset[Character] = spark.sqlContext.read
-    .option("header", "true")
-    .option("delimiter", ";")
-    .option("inferSchema", "true")
-    .csv("StarWars.csv")
-    .as[Character]
+    val characters: Dataset[Character] = spark.sqlContext.read
+      .option("header", "true")
+      .option("delimiter", ",")
+      .option("inferSchema", "true")
+      .csv(s"${inputDirectory.getPath}/starwars.csv")
+      .as[Character]
 
-  characters.show()
-  val sw_df = characters.join(friends, Seq("name"))
-  sw_df.show()
+    characters.show()
+    val sw_df = characters.join(friends, Seq("name"))
+    sw_df.show()
 
-  case class SW(
-      name: String,
-      height: Int,
-      weight: Option[Int],
-      eyecolor: Option[String],
-      haircolor: Option[String],
-      jedi: String,
-      species: String,
-      friends: String
-  )
+    case class SW(
+        name: String,
+        height: Int,
+        weight: Option[Int],
+        eyecolor: Option[String],
+        haircolor: Option[String],
+        jedi: String,
+        species: String,
+        friends: String
+    )
 
-  val sw_ds = sw_df.as[SW]
+    val sw_ds = sw_df.as[SW]
+
+  finally spark.close()

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.1
+sbt.version=1.8.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.7")
 addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "1.0.1")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")


### PR DESCRIPTION
Hello @vincenzobaz

I wanted to evaluate use of Scala 3 in our project that uses spark and came across your project and found it very useful.
However code generation did not work entirely, since we also rely on collections in our case classes used in spark.
Hence I've tried my best to add most of the datatypes that are supported in spark sql.

Maybe you can have a look at the PR - sorry it is quite big. I also added sbt-scalafmt which makes it possible to use scalafmtAll and scalafmtSbt inside sbt.

There is one long-ish and quirky matching expression at the end of Serializer and Deserializer in summonAll which makes it possible now to encode and decoder very long data types. I know that it is generally possible to do so when increasing "-Xmax-inlines:256" for example - but with this "bulk-processing" of the tuples that I added: I don't need that setting in our project and it doesn't crash the compiler with a stackoverflow. I tried to fix that stackoverflow but it seems the best way to do so is to restrict the stack size of that summonAll expression otherwise the compiler will crash occasionally in our project, especially when clean building.

I also added myself as a developer - I hope that is OK.

I also hope that this PR is OK - or give me your thoughts and please review. Thanks!

Regards
Michael

btw - this is the 2nd try for the PR - this time with the correct branches (I hope)