### PR TITLE
add support for parsing java.lang.Double

### DIFF
--- a/encoders/src/main/scala/scala3encoders/derivation/Deserializer.scala
+++ b/encoders/src/main/scala/scala3encoders/derivation/Deserializer.scala
@@ -67,6 +67,11 @@ object Deserializer:
       createDeserializerForTypesSupportValueOf(path, classOf[java.lang.Double])
     override def nullable: Boolean = false
 
+  given given_Deserializer_JavaDouble: Deserializer[java.lang.Double] with
+    def inputType: DataType = DoubleType
+    def deserialize(path: Expression): Expression =
+      createDeserializerForTypesSupportValueOf(path, classOf[java.lang.Double])
+
   given Deserializer[Float] with
     def inputType: DataType = FloatType
     def deserialize(path: Expression): Expression =

--- a/encoders/src/main/scala/scala3encoders/derivation/Serializer.scala
+++ b/encoders/src/main/scala/scala3encoders/derivation/Serializer.scala
@@ -47,6 +47,10 @@ object Serializer:
     def inputType: DataType = DoubleType
     def serialize(inputObject: Expression): Expression = inputObject
 
+  given given_Serializer_JavaDouble: Serializer[java.lang.Double] with
+    def inputType: DataType = DoubleType
+    def serialize(inputObject: Expression): Expression = inputObject
+
   given Serializer[Float] with
     def inputType: DataType = FloatType
     def serialize(inputObject: Expression): Expression = inputObject


### PR DESCRIPTION
This was just something I used personally so I thought I might as well do a pull request. I'm not sure if you are happy with the names I had to give to the givens though (as to not conflict with the generated name of the serializer/deserializer of Double).