### PR TITLE
fix option in udf

### DIFF
--- a/encoders/src/main/scala/scala3encoders/derivation/Deserializer.scala
+++ b/encoders/src/main/scala/scala3encoders/derivation/Deserializer.scala
@@ -33,8 +33,7 @@ object Deserializer:
       ct: ClassTag[T]
   ): Deserializer[Option[T]] =
     new Deserializer[Option[T]]:
-      override def inputType: DataType =
-        ObjectType(ct.runtimeClass)
+      override def inputType: DataType = d.inputType
 
       override def deserialize(path: Expression): Expression =
         val tpe = ScalaReflection.typeBoxedJavaMapping.getOrElse(


### PR DESCRIPTION
fixes #36 

using the original type in Deserializer seems OK (all other tests keep working as well) - in Serializer we have to use the more complicated version as it is