### PR TITLE
check types in deserialization

### DIFF
--- a/encoders/src/main/scala/scala3encoders/derivation/Deserializer.scala
+++ b/encoders/src/main/scala/scala3encoders/derivation/Deserializer.scala
@@ -4,11 +4,9 @@ import scala.compiletime.{constValue, summonInline, erasedValue}
 import scala.deriving.Mirror
 import scala.reflect.ClassTag
 
-import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
+import org.apache.spark.sql.catalyst.expressions.{Expression}
 import org.apache.spark.sql.catalyst.DeserializerBuildHelper.*
 import org.apache.spark.sql.catalyst.WalkedTypePath
-import org.apache.spark.sql.catalyst.analysis.UnresolvedExtractValue
-import org.apache.spark.sql.catalyst.expressions.GetStructField
 import org.apache.spark.sql.catalyst.expressions.objects._
 import org.apache.spark.sql.helper.Helper
 
@@ -226,16 +224,36 @@ object Deserializer:
       )
     def cls = classTag.runtimeClass
     def isTuple = cls.getName.startsWith("scala.Tuple")
+    val walkedTypePath = WalkedTypePath()
 
     new Deserializer[T]:
       override def inputType: DataType = StructType(fields)
       override def deserialize(path: Expression): Expression =
+        // code is partly taken from `DeserializerBuildHelper.createDeserializer`: `case ProductEncoder`
         val arguments = elems.zipWithIndex.map {
           case ((label, deserializer), i) =>
-            val newPath =
-              if (isTuple) then GetStructField(path, i)
-              else UnresolvedExtractValue(path, Literal(label))
-            deserializer.deserialize(newPath)
+            val newTypePath = walkedTypePath.recordField(cls.getName, label)
+            // For tuples, we grab the inner fields by ordinal instead of name.
+            val getter = if (isTuple) {
+              addToPathOrdinal(
+                path,
+                i,
+                deserializer.inputType,
+                newTypePath
+              )
+            } else {
+              addToPath(
+                path,
+                label,
+                deserializer.inputType,
+                newTypePath
+              )
+            }
+            expressionWithNullSafety(
+              deserializer.deserialize(getter),
+              deserializer.nullable,
+              newTypePath
+            )
         }
         NewInstance(cls, arguments, ObjectType(cls), false)
 

--- a/encoders/src/test/scala/sql/EncoderDerivationSpec.scala
+++ b/encoders/src/test/scala/sql/EncoderDerivationSpec.scala
@@ -364,10 +364,10 @@ class EncoderDerivationSpec extends munit.FunSuite with SparkSqlTesting:
     // create temporary csv file
     val file = File.createTempFile("test", ".csv")
     val lines = """name;lat;lon
-Berlin;52.520008;13.40
-Madrid;40.416775;-3.70
-New York;40.730610;-73.935242
-"""
+                |Berlin;52.520008;13.40
+                |Madrid;40.416775;-3.70
+                |New York;40.730610;-73.935242
+                |""".stripMargin
     // write lines to file
     val pw = new PrintWriter(file)
     pw.write(lines)

--- a/encoders/src/test/scala/sql/EncoderDerivationSpec.scala
+++ b/encoders/src/test/scala/sql/EncoderDerivationSpec.scala
@@ -1,9 +1,10 @@
 package scala3encoders
 
-import org.apache.spark.sql.Encoder
+import org.apache.spark.sql.{AnalysisException, Encoder}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+import java.io.{File, PrintWriter}
 
 case class A()
 case class B(x: String)
@@ -130,6 +131,7 @@ final case class ChkMap(
 case class Sequence(id: Int, nums: Seq[Int])
 
 case class City(name: String, lat: Double, lon: Double)
+case class CityWithInts(name: String, lat: Int, lon: Int)
 case class Journey(id: Int, cities: Seq[City])
 
 val dSchema =
@@ -356,4 +358,43 @@ class EncoderDerivationSpec extends munit.FunSuite with SparkSqlTesting:
         92, 93, 94, 95, 96, 97, 98, 99)
     )
     assertEquals(input.toDS.collect.toSeq, input)
+  }
+
+  test("check cast is checked") {
+    // create temporary csv file
+    val file = File.createTempFile("test", ".csv")
+    val lines = """name;lat;lon
+Berlin;52.520008;13.40
+Madrid;40.416775;-3.70
+New York;40.730610;-73.935242
+"""
+    // write lines to file
+    val pw = new PrintWriter(file)
+    pw.write(lines)
+    pw.close()
+
+    val df = spark.sqlContext.read
+      .option("header", "true")
+      .option("delimiter", ";")
+      .option("inferSchema", "true")
+      .csv(file.getAbsolutePath())
+
+    val exception = intercept[AnalysisException] {
+      df.as[CityWithInts]
+    }
+    assert(
+      clue(exception.getMessage).contains(
+        "[CANNOT_UP_CAST_DATATYPE] Cannot up cast lat from \"DOUBLE\" to \"INT\"."
+      )
+    )
+
+    val cities = df.as[City]
+    assertEquals(
+      cities.collect.toList,
+      List(
+        City("Berlin", 52.520008, 13.40),
+        City("Madrid", 40.416775, -3.70),
+        City("New York", 40.730610, -73.935242)
+      )
+    )
   }

--- a/examples/src/main/scala/sql/StarWars.scala
+++ b/examples/src/main/scala/sql/StarWars.scala
@@ -1,64 +1,76 @@
 package sql
 
 import buildinfo.BuildInfo.inputDirectory
-import org.apache.spark.sql.{Dataset, Encoder, Row, SparkSession}
+import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.apache.spark.sql.functions.col
+
 import scala3encoders.given
 
-object StarWars extends App:
+object StarWarsData:
   val spark = SparkSession.builder().master("local").getOrCreate
   import spark.implicits._
 
-  try
-    case class Friends(name: String, friends: String)
-    val friends: Dataset[Friends] = Seq(
-      ("Yoda", "Obi-Wan Kenobi"),
-      ("Anakin Skywalker", "Sheev Palpatine"),
-      ("Luke Skywalker", "Han Solo, Leia Skywalker"),
-      ("Leia Skywalker", "Obi-Wan Kenobi"),
-      ("Sheev Palpatine", "Anakin Skywalker"),
-      ("Han Solo", "Leia Skywalker, Luke Skywalker, Obi-Wan Kenobi, Chewbacca"),
-      ("Obi-Wan Kenobi", "Yoda, Qui-Gon Jinn"),
-      ("R2-D2", "C-3PO"),
-      ("C-3PO", "R2-D2"),
-      ("Darth Maul", "Sheev Palpatine"),
-      ("Chewbacca", "Han Solo"),
-      ("Lando Calrissian", "Han Solo"),
-      ("Jabba", "Boba Fett")
-    ).map(Friends.apply).toDS
+  case class Friends(name: String, friends: String)
+  val friends: Dataset[Friends] = Seq(
+    ("Yoda", "Obi-Wan Kenobi"),
+    ("Anakin Skywalker", "Sheev Palpatine"),
+    ("Luke Skywalker", "Han Solo, Leia Skywalker"),
+    ("Leia Skywalker", "Obi-Wan Kenobi"),
+    ("Sheev Palpatine", "Anakin Skywalker"),
+    ("Han Solo", "Leia Skywalker, Luke Skywalker, Obi-Wan Kenobi, Chewbacca"),
+    ("Obi-Wan Kenobi", "Yoda, Qui-Gon Jinn"),
+    ("R2-D2", "C-3PO"),
+    ("C-3PO", "R2-D2"),
+    ("Darth Maul", "Sheev Palpatine"),
+    ("Chewbacca", "Han Solo"),
+    ("Lando Calrissian", "Han Solo"),
+    ("Jabba", "Boba Fett")
+  ).map(Friends.apply).toDS
 
-    friends.show()
-    case class FriendsMissing(who: String, friends: Option[String])
-    val dsMissing: Dataset[FriendsMissing] = Seq(
-      ("Yoda", Some("Obi-Wan Kenobi")),
-      ("Anakin Skywalker", Some("Sheev Palpatine")),
-      ("Luke Skywalker", Option.empty[String]),
-      ("Leia Skywalker", Some("Obi-Wan Kenobi")),
-      ("Sheev Palpatine", Some("Anakin Skywalker")),
-      ("Han Solo", Some("Leia Skywalker, Luke Skywalker, Obi-Wan Kenobi"))
-    ).map(FriendsMissing.apply).toDS
+  case class FriendsMissing(who: String, friends: Option[String])
+  val dsMissing: Dataset[FriendsMissing] = Seq(
+    ("Yoda", Some("Obi-Wan Kenobi")),
+    ("Anakin Skywalker", Some("Sheev Palpatine")),
+    ("Luke Skywalker", Option.empty[String]),
+    ("Leia Skywalker", Some("Obi-Wan Kenobi")),
+    ("Sheev Palpatine", Some("Anakin Skywalker")),
+    ("Han Solo", Some("Leia Skywalker, Luke Skywalker, Obi-Wan Kenobi"))
+  ).map(FriendsMissing.apply).toDS
 
-    dsMissing.show()
+  case class Character(
+      name: String,
+      height: Double,
+      weight: Option[Double],
+      eyecolor: Option[String],
+      haircolor: Option[String],
+      jedi: Boolean,
+      species: String
+  )
 
-    case class Character(
-        name: String,
-        height: Double,
-        weight: Option[Double],
-        eyecolor: Option[String],
-        haircolor: Option[String],
-        jedi: Boolean,
-        species: String
+  val df = spark.sqlContext.read
+    .option("header", "true")
+    .option("delimiter", ",")
+    .option("inferSchema", "true")
+    .csv(s"${inputDirectory.getPath}/starwars.csv")
+
+  // going via java interface here of DataFrame map function here
+  val characters = df
+    .select(
+      classOf[Character].getDeclaredFields
+        .filterNot(_.isSynthetic)
+        .map(_.getName)
+        .map(col): _*
     )
-
-    val df = spark.sqlContext.read
-      .option("header", "true")
-      .option("delimiter", ",")
-      .option("inferSchema", "true")
-      .csv(s"${inputDirectory.getPath}/starwars.csv")
-
-    // going via java interface here of DataFrame map function here
-    val toCharacter =
-      new org.apache.spark.api.java.function.MapFunction[Row, Character] {
+    .map {
+      case Row(
+            name: String,
+            height: Double,
+            weight: String,
+            eyecolor: String,
+            haircolor: String,
+            jedi: String,
+            species: String
+          ) =>
         def getOpt(s: String): Option[String] = s match {
           case "NA" => None
           case s    => Some(s)
@@ -67,49 +79,38 @@ object StarWars extends App:
           case "NA" => None
           case s    => Some(s.toDouble)
         }
-        override def call(row: Row): Character = row match {
-          case Row(
-                name: String,
-                height: Double,
-                weight: String,
-                eyecolor: String,
-                haircolor: String,
-                jedi: String,
-                species: String
-              ) =>
-            // calling Character.apply wouldn't work here!
-            new Character(
-              name,
-              height,
-              getDoubleOpt(weight),
-              getOpt(eyecolor),
-              getOpt(haircolor),
-              jedi == "jedi",
-              species
-            )
-        }
-      }
-    val characters = df
-      .select(
-        classOf[Character].getDeclaredFields.map(_.getName).map(col): _*
-      )
-      .map(toCharacter, summon[Encoder[Character]])
+        // calling Character.apply wouldn't work here!
+        new Character(
+          name,
+          height,
+          getDoubleOpt(weight),
+          getOpt(eyecolor),
+          getOpt(haircolor),
+          jedi == "jedi",
+          species
+        )
+    }
+
+  val sw_df = characters.join(friends, Seq("name"))
+
+  case class SW(
+      name: String,
+      height: Double,
+      weight: Option[Double],
+      eyecolor: Option[String],
+      haircolor: Option[String],
+      jedi: String,
+      species: String,
+      friends: String
+  )
+
+  val sw_ds = sw_df.as[SW]
+
+object StarWars extends App:
+  import StarWarsData._
+  try
+    friends.show()
+    dsMissing.show()
     characters.show()
-
-    val sw_df = characters.join(friends, Seq("name"))
-    sw_df.show()
-
-    case class SW(
-        name: String,
-        height: Double,
-        weight: Option[Double],
-        eyecolor: Option[String],
-        haircolor: Option[String],
-        jedi: String,
-        species: String,
-        friends: String
-    )
-
-    val sw_ds = sw_df.as[SW]
-
+    sw_ds.show()
   finally spark.close()

--- a/examples/src/main/scala/sql/StarWars.scala
+++ b/examples/src/main/scala/sql/StarWars.scala
@@ -1,18 +1,62 @@
 package sql
 
 import buildinfo.BuildInfo.inputDirectory
-import org.apache.spark.sql.{Dataset, Encoder, SparkSession}
+import org.apache.spark.sql.{DataFrame, Dataset, Encoder, SparkSession}
+import org.apache.spark.sql.functions.col
+import scala3encoders.given
+import scala3udf.{
+  // "old" udf doesn't interfer with new scala3udf.udf when renamed
+  Udf => udf
+}
+import scala.reflect.ClassTag
+
+def map_udf[T](df: DataFrame, fn: udf)(implicit
+    ct: ClassTag[T],
+    enc: Encoder[T]
+): Dataset[T] = {
+  val columns = ct.runtimeClass.getDeclaredFields.map(_.getName).toList.map(col)
+  df.select(fn(columns: _*).alias("udf")).select("udf.*").as[T]
+}
+
+case class Character(
+    name: String,
+    height: Double,
+    weight: Option[Double],
+    eyecolor: Option[String],
+    haircolor: Option[String],
+    jedi: Boolean,
+    species: String
+)
+
+def toOption[T](what: String, parse: String => T) =
+  if (what == "NA") None else Some(parse(what))
+
+val character = udf(
+  (
+      name: String,
+      height: Double,
+      weight: String,
+      eyecolor: String,
+      haircolor: String,
+      jedi: String,
+      species: String
+  ) =>
+    Character(
+      name,
+      height,
+      toOption(weight, _.toString.toDouble),
+      toOption(eyecolor, _.toString),
+      toOption(haircolor, _.toString),
+      jedi == "jedi",
+      species
+    )
+)
 
 object StarWars extends App:
   val spark = SparkSession.builder().master("local").getOrCreate
-  import spark.implicits.localSeqToDatasetHolder
-  import scala3encoders.given
+  import spark.implicits._
 
   try
-    extension [T: Encoder](seq: Seq[T])
-      def toDS: Dataset[T] =
-        localSeqToDatasetHolder(seq).toDS
-
     case class Friends(name: String, friends: String)
     val friends: Dataset[Friends] = Seq(
       ("Yoda", "Obi-Wan Kenobi"),
@@ -43,31 +87,21 @@ object StarWars extends App:
 
     dsMissing.show()
 
-    case class Character(
-        name: String,
-        height: Int,
-        weight: Option[Int],
-        eyecolor: Option[String],
-        haircolor: Option[String],
-        jedi: String,
-        species: String
-    )
-
-    val characters: Dataset[Character] = spark.sqlContext.read
+    val df = spark.sqlContext.read
       .option("header", "true")
       .option("delimiter", ",")
       .option("inferSchema", "true")
       .csv(s"${inputDirectory.getPath}/starwars.csv")
-      .as[Character]
 
+    val characters = map_udf[Character](df, character)
     characters.show()
     val sw_df = characters.join(friends, Seq("name"))
     sw_df.show()
 
     case class SW(
         name: String,
-        height: Int,
-        weight: Option[Int],
+        height: Double,
+        weight: Option[Double],
         eyecolor: Option[String],
         haircolor: Option[String],
         jedi: String,

--- a/examples/src/main/scala/sql/StarWars.scala
+++ b/examples/src/main/scala/sql/StarWars.scala
@@ -75,12 +75,9 @@ object StarWarsData:
           case "NA" => None
           case s    => Some(s)
         }
-        def getDoubleOpt(s: String): Option[Double] = s match {
-          case "NA" => None
-          case s    => Some(s.toDouble)
-        }
-        // calling Character.apply wouldn't work here!
-        new Character(
+        def getDoubleOpt(s: String): Option[Double] = getOpt(s).map(_.toDouble)
+        
+        Character(
           name,
           height,
           getDoubleOpt(weight),


### PR DESCRIPTION
This is a part-solution for the problems with the `collect` done in the StarWars example.
With this code in place (which was mostly taken over from spark code - see comment) the cast checks are active.
See also the added test which only works with these changes.