### PR TITLE
Fix custom encoder to a primitive type wrapped in an Option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 **/metals.sbt
 project/.bloop
 *.log
+.idea

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Apache Spark.
 Add the following dependency to your `build.sbt`:
 
 ```
-"io.github.vincenzobaz" %% "spark-scala3-encoders" % "0.2.3"
-"io.github.vincenzobaz" %% "spark-scala3-udf" % "0.2.3"
+"io.github.vincenzobaz" %% "spark-scala3-encoders" % "0.2.4"
+"io.github.vincenzobaz" %% "spark-scala3-udf" % "0.2.4"
 ```
 
 ## Apache Spark version

--- a/encoders/src/main/scala/scala3encoders/derivation/Deserializer.scala
+++ b/encoders/src/main/scala/scala3encoders/derivation/Deserializer.scala
@@ -18,20 +18,15 @@ trait Deserializer[T]:
   def nullable: Boolean = true
 
 object Deserializer:
-
-  // see ScalaReflection.deserializerFor
+  // See DeserializerBuildHelper.createDeserializer
   inline given deriveOpt[T](using
       d: Deserializer[T],
       ct: ClassTag[T]
   ): Deserializer[Option[T]] =
     new Deserializer[Option[T]]:
       override def inputType: DataType = d.inputType
-
       override def deserialize(path: Expression): Expression =
-        val tpe = Helper.typeBoxedJavaMapping.getOrElse(
-          d.inputType,
-          ct.runtimeClass
-        )
+        val tpe = Helper.typeBoxedJavaMapping.getOrElse(ct.runtimeClass, ct.runtimeClass)
         WrapOption(d.deserialize(path), ObjectType(tpe))
 
   given Deserializer[Int] with

--- a/encoders/src/main/scala/scala3encoders/derivation/Helper.scala
+++ b/encoders/src/main/scala/scala3encoders/derivation/Helper.scala
@@ -11,22 +11,19 @@ import org.apache.spark.sql.catalyst.WalkedTypePath
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
-// This is copied from spark  to support older versions of Spark and 3.5.0 -
+// This is copied from spark to support older versions of Spark and 3.5.0 -
 // it was part of ScalaReflection and was moved to EncoderUtils in 3.5.0
 object Helper {
   private val nullOnOverflow = !SQLConf.get.ansiEnabled
 
-  val typeBoxedJavaMapping: Map[DataType, Class[_]] = Map[DataType, Class[_]](
-    BooleanType -> classOf[java.lang.Boolean],
-    ByteType -> classOf[java.lang.Byte],
-    ShortType -> classOf[java.lang.Short],
-    IntegerType -> classOf[java.lang.Integer],
-    LongType -> classOf[java.lang.Long],
-    FloatType -> classOf[java.lang.Float],
-    DoubleType -> classOf[java.lang.Double],
-    DateType -> classOf[java.lang.Integer],
-    TimestampType -> classOf[java.lang.Long],
-    TimestampNTZType -> classOf[java.lang.Long]
+  val typeBoxedJavaMapping: Map[Class[?], Class[?]] = Map[Class[?], Class[?]](
+    classOf[Boolean] -> classOf[java.lang.Boolean],
+    classOf[Byte] -> classOf[java.lang.Byte],
+    classOf[Short] -> classOf[java.lang.Short],
+    classOf[Int] -> classOf[java.lang.Integer],
+    classOf[Long] -> classOf[java.lang.Long],
+    classOf[Float] -> classOf[java.lang.Float],
+    classOf[Double] -> classOf[java.lang.Double]
   )
 
   def createSerializerForBigInteger(inputObject: Expression): Expression = {


### PR DESCRIPTION
The test is not working without the changes.
This means we cannot write custom Encoders for any type if they map to a primitive type and are wrapped in an Option (without the option it's fine).

(I've been tracking this bug for days now 😞)