### PR TITLE
Fix and test BigDecimal and BigInteger handling

### DIFF
--- a/encoders/src/main/scala/scala3encoders/derivation/Deserializer.scala
+++ b/encoders/src/main/scala/scala3encoders/derivation/Deserializer.scala
@@ -12,6 +12,8 @@ import org.apache.spark.sql.types.*
 import scala.concurrent.duration.FiniteDuration
 import scala.jdk.javaapi.DurationConverters
 
+import java.math.{BigDecimal => JavaBigDecimal, BigInteger => JavaBigInteger}
+
 trait Deserializer[T]:
   def inputType: DataType
   def deserialize(path: Expression): Expression
@@ -129,19 +131,25 @@ object Deserializer:
     def deserialize(path: Expression): Expression =
       createDeserializerForString(path, false)
 
-  given Deserializer[BigDecimal] with
+  given Deserializer[JavaBigDecimal] with
     def inputType: DataType =
       DecimalType.SYSTEM_DEFAULT
     def deserialize(path: Expression): Expression =
       createDeserializerForJavaBigDecimal(path, returnNullable = false)
 
-  given Deserializer[java.math.BigInteger] with
+  given Deserializer[BigDecimal] with
+    def inputType: DataType =
+      DecimalType.SYSTEM_DEFAULT
+    def deserialize(path: Expression): Expression =
+      createDeserializerForScalaBigDecimal(path, returnNullable = false)
+
+  given Deserializer[JavaBigInteger] with
     def inputType: DataType =
       DecimalType(38, 0) // .BigIntDecimal is private
     def deserialize(path: Expression): Expression =
       createDeserializerForJavaBigInteger(path, returnNullable = false)
 
-  given Deserializer[scala.math.BigInt] with
+  given Deserializer[BigInt] with
     def inputType: DataType =
       DecimalType(38, 0) // .BigIntDecimal is private
     def deserialize(path: Expression): Expression =

--- a/encoders/src/main/scala/scala3encoders/derivation/Helper.scala
+++ b/encoders/src/main/scala/scala3encoders/derivation/Helper.scala
@@ -40,6 +40,20 @@ object Helper {
     )
   }
 
+  def createSerializerForBigDecimal(inputObject: Expression): Expression = {
+    CheckOverflow(
+      StaticInvoke(
+        Decimal.getClass,
+        DecimalType(38, 18),
+        "apply",
+        inputObject :: Nil,
+        returnNullable = false
+      ),
+      DecimalType(38, 18),
+      nullOnOverflow
+    )
+  }
+
   private def upCastToExpectedType(
       expr: Expression,
       expected: DataType,

--- a/encoders/src/main/scala/scala3encoders/derivation/Serializer.scala
+++ b/encoders/src/main/scala/scala3encoders/derivation/Serializer.scala
@@ -11,6 +11,8 @@ import org.apache.spark.sql.types.*
 import scala.concurrent.duration.FiniteDuration
 import scala.jdk.javaapi.DurationConverters
 
+import java.math.{BigDecimal => JavaBigDecimal, BigInteger => JavaBigInteger}
+
 trait Serializer[T]:
   def inputType: DataType
   def serialize(inputObject: Expression): Expression
@@ -114,10 +116,15 @@ object Serializer:
   given Serializer[BigDecimal] with
     def inputType: DataType = ObjectType(classOf[BigDecimal])
     def serialize(inputObject: Expression): Expression =
-      Helper.createSerializerForBigInteger(inputObject)
+      Helper.createSerializerForBigDecimal(inputObject)
 
-  given Serializer[java.math.BigInteger] with
-    def inputType: DataType = ObjectType(classOf[java.math.BigInteger])
+  given Serializer[JavaBigDecimal] with
+    def inputType: DataType = ObjectType(classOf[JavaBigDecimal])
+    def serialize(inputObject: Expression): Expression =
+      Helper.createSerializerForBigDecimal(inputObject)
+
+  given Serializer[JavaBigInteger] with
+    def inputType: DataType = ObjectType(classOf[JavaBigInteger])
     def serialize(inputObject: Expression): Expression =
       Helper.createSerializerForBigInteger(inputObject)
 

--- a/encoders/src/test/scala/sql/DerivationTests.scala
+++ b/encoders/src/test/scala/sql/DerivationTests.scala
@@ -2,7 +2,7 @@ package scala3encoders
 
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.Encoder
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.*
 
 class DerivationTests extends munit.FunSuite:
   test("derive encoder of case class C(x: Int, y: Long)") {
@@ -13,6 +13,34 @@ class DerivationTests extends munit.FunSuite:
         Seq(
           StructField("x", IntegerType),
           StructField("y", LongType)
+        )
+      )
+    )
+  }
+
+  test("derive encoder of case class with Scala BigDecimal and BigInt") {
+    val encoder = summon[Encoder[G]]
+      .asInstanceOf[ExpressionEncoder[G]]
+    assertEquals(
+      encoder.schema,
+      StructType(
+        Seq(
+          StructField("x", DecimalType(38, 18)),
+          StructField("y", DecimalType(38, 0))
+        )
+      )
+    )
+  }
+
+  test("derive encoder of case class with Java BigDecimal and BigInteger") {
+    val encoder = summon[Encoder[H]]
+      .asInstanceOf[ExpressionEncoder[H]]
+    assertEquals(
+      encoder.schema,
+      StructType(
+        Seq(
+          StructField("x", DecimalType(38, 18)),
+          StructField("y", DecimalType(38, 0))
         )
       )
     )


### PR DESCRIPTION
While using scala3encoders on some external data represented as BigDecimal in parquet,
I discovered a few issues with the big decimal and big int(eger) handling and corrected
for them, along with tests.

The choice of BigDecimal(38,18) for precision is an arbitrary choice but seems to be something
of a standard for Parquet from what I can see.