### PR TITLE
Loosen null strictness on AgnosticEncoders

### DIFF
--- a/encoders4/src/main/scala/scala3encoders/EncoderDerivation.scala
+++ b/encoders4/src/main/scala/scala3encoders/EncoderDerivation.scala
@@ -66,7 +66,7 @@ given [O: AgnosticEncoder]: AgnosticEncoder[Option[O]] =
   AgnosticEncoders.OptionEncoder(summon[AgnosticEncoder[O]])
 given [O: AgnosticEncoder]: AgnosticEncoder[Array[O]] =
   val enc = summon[AgnosticEncoder[O]]
-  AgnosticEncoders.ArrayEncoder(summon[AgnosticEncoder[O]], containsNull = enc.nullable)
+  AgnosticEncoders.ArrayEncoder(enc, containsNull = enc.nullable)
 
 given [C[_], E](using
     ev: C[E] <:< Iterable[E],

--- a/encoders4/src/main/scala/scala3encoders/EncoderDerivation.scala
+++ b/encoders4/src/main/scala/scala3encoders/EncoderDerivation.scala
@@ -65,14 +65,15 @@ given AgnosticEncoder[JBigDecimal] =
 given [O: AgnosticEncoder]: AgnosticEncoder[Option[O]] =
   AgnosticEncoders.OptionEncoder(summon[AgnosticEncoder[O]])
 given [O: AgnosticEncoder]: AgnosticEncoder[Array[O]] =
-  AgnosticEncoders.ArrayEncoder(summon[AgnosticEncoder[O]], false)
+  val enc = summon[AgnosticEncoder[O]]
+  AgnosticEncoders.ArrayEncoder(summon[AgnosticEncoder[O]], containsNull = enc.nullable)
 
 given [C[_], E](using
     ev: C[E] <:< Iterable[E],
     classTag: ClassTag[C[E]],
     element: AgnosticEncoder[E]
 ): AgnosticEncoder[C[E]] =
-  AgnosticEncoders.IterableEncoder(classTag, element, false, false)
+  AgnosticEncoders.IterableEncoder(classTag, element, containsNull = element.nullable, lenientSerialization = false)
 
 given [M[_, _], K, V](using
     ev: M[K, V] <:< Map[K, V],
@@ -80,14 +81,14 @@ given [M[_, _], K, V](using
     key: AgnosticEncoder[K],
     value: AgnosticEncoder[V]
 ): AgnosticEncoder[M[K, V]] =
-  AgnosticEncoders.MapEncoder(classTag, key, value, false)
+  AgnosticEncoders.MapEncoder(classTag, key, value, valueContainsNull = value.nullable)
 
 private inline def summonAll[T <: Tuple, U <: Tuple]: List[EncoderField] =
   def encoder[T](label: String, enc: AgnosticEncoder[T]) =
     EncoderField(
       label,
       enc,
-      false,
+      nullable = enc.nullable,
       MetadataBuilder()
         .build() // TODO: Is this ok? what about the two other fields
     )

--- a/encoders4/src/test/scala/sql/DerivationTests.scala
+++ b/encoders4/src/test/scala/sql/DerivationTests.scala
@@ -25,8 +25,8 @@ class DerivationTests extends munit.FunSuite:
       encoder.schema,
       StructType(
         Seq(
-          StructField("x", DecimalType(38, 18), nullable = false),
-          StructField("y", DecimalType(38, 0), nullable = false)
+          StructField("x", DecimalType(38, 18), nullable = true),
+          StructField("y", DecimalType(38, 0), nullable = true)
         )
       )
     )
@@ -39,8 +39,8 @@ class DerivationTests extends munit.FunSuite:
       encoder.schema,
       StructType(
         Seq(
-          StructField("x", DecimalType(38, 18), nullable = false),
-          StructField("y", DecimalType(38, 0), nullable = false)
+          StructField("x", DecimalType(38, 18), nullable = true),
+          StructField("y", DecimalType(38, 0), nullable = true)
         )
       )
     )
@@ -123,7 +123,7 @@ class DerivationTests extends munit.FunSuite:
             MapType(
               IntegerType,
               StringType,
-              false
+              valueContainsNull = true
             ),
             nullable = true
           )

--- a/encoders4/src/test/scala/sql/EncoderDerivationSpec.scala
+++ b/encoders4/src/test/scala/sql/EncoderDerivationSpec.scala
@@ -62,7 +62,7 @@ class EncoderDerivationSpec extends munit.FunSuite with SparkSqlTesting:
     val encoder = summon[Encoder[B]]
     assertEquals(
       encoder.schema,
-      StructType(Seq(StructField("x", StringType, nullable = false)))
+      StructType(Seq(StructField("x", StringType, nullable = true)))
     )
 
     val input = Seq(B("hello"), B("world"))
@@ -109,11 +109,11 @@ class EncoderDerivationSpec extends munit.FunSuite with SparkSqlTesting:
       encoder.schema,
       StructType(
         Seq(
-          StructField("x", StringType, nullable = false),
+          StructField("x", StringType, nullable = true),
           StructField(
             "y",
-            StructType(Seq(StructField("x", StringType, nullable = false))),
-            nullable = false
+            StructType(Seq(StructField("x", StringType, nullable = true))),
+            nullable = true
           )
         )
       )
@@ -284,14 +284,14 @@ class EncoderDerivationSpec extends munit.FunSuite with SparkSqlTesting:
             MapType(
               StructType(
                 Seq(
-                  StructField("id", StringType, false),
-                  StructField("date", DateType, false)
+                  StructField("id", StringType, nullable = true),
+                  StructField("date", DateType, nullable = true)
                 )
               ),
               LongType,
-              false
+              valueContainsNull = false
             ),
-            false
+            nullable = true
           )
         )
       )


### PR DESCRIPTION
When upgrading several of our projects to use the new spark 4 agnostic encoders, I noticed a lot of spark-cluster based failures due to null pointer exceptions happening in the executors, and spark being unable to continue in those cases.

I believe I have tracked the problem down to various `containsNull` style parameters in the agnostic encoder definitions which were being observed strictly by the catalyst generated code, and causing these problems. While I am not certain my solution here is the correct one, what I did was replaced the `false` values in these cases with the `nullable` value from the donor encoder being represented by the product or other derivative encoder, and this fixed all of my problems/tests. I'm happy to discuss this approach and the intent behind the change, and see if there might be a better way to achieve this.

The problems manifested in a couple of ways (and this change fixes them all):

String fields that were previously nullable with spark 3 were failing in the executors with a null pointer exception in the input.getBytes (and other methods on the input parameter) due to the null being presented when it wasn't expected. This could be fixed by making the String optional (and maybe should be) but it's a pervasive problem and the default behavior for String agnostic encoders is to allow the nullables, so there's an argument to be made that the products and other derivatives should allow the same.

The more difficult case was on type-safe joins. For joins other than inner, one or other side could end up null in the resulting product tuple and this was manifesting as failures in the executors. Loosening the strictness fixed this case as well.